### PR TITLE
MOTECH-1929: Added the ability to pass extra data with stock tasks

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/events/constants/DisplayNames.java
+++ b/commcare/src/main/java/org/motechproject/commcare/events/constants/DisplayNames.java
@@ -19,6 +19,7 @@ public final class DisplayNames {
     public static final String STOCK_ON_HAND = "commcare.stockOnHand";
     public static final String TRANSACTION_DATE = "commcare.transactionDate";
     public static final String TYPE = "commcare.type";
+    public static final String EXTRA_DATA = "commcare.extraData";
 
     /**
      * Utility class, should not be initiated.

--- a/commcare/src/main/java/org/motechproject/commcare/events/constants/EventDataKeys.java
+++ b/commcare/src/main/java/org/motechproject/commcare/events/constants/EventDataKeys.java
@@ -56,6 +56,7 @@ public final class EventDataKeys {
     public static final String SECTION_ID = "section_id";
     public static final String START_DATE = "start_date";
     public static final String END_DATE = "end_date";
+    public static final String EXTRA_DATA = "extra_data";
 
     //ReceivedStockTransactionEvent
     public static final String PRODUCT_ID = "product_id";

--- a/commcare/src/main/java/org/motechproject/commcare/tasks/builder/QueryStockLedgerActionBuilder.java
+++ b/commcare/src/main/java/org/motechproject/commcare/tasks/builder/QueryStockLedgerActionBuilder.java
@@ -15,14 +15,15 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import static org.motechproject.tasks.domain.ParameterType.DATE;
+import static org.motechproject.tasks.domain.ParameterType.MAP;
+import static org.motechproject.tasks.domain.ParameterType.UNICODE;
+
 /**
  * Responsible for building actions for querying stock ledger for all configurations. There action can then be used in
  * the task module.
  */
 public class QueryStockLedgerActionBuilder {
-
-    private static final String UNICODE = "UNICODE";
-    private static final String DATE = "DATE";
 
     private CommcareConfigService configService;
 
@@ -47,7 +48,7 @@ public class QueryStockLedgerActionBuilder {
             builder = new ActionParameterRequestBuilder()
                     .setDisplayName(DisplayNames.CASE_ID)
                     .setKey(EventDataKeys.CASE_ID)
-                    .setType(UNICODE)
+                    .setType(UNICODE.getValue())
                     .setRequired(true)
                     .setOrder(order++);
             parameters.add(builder.createActionParameterRequest());
@@ -55,7 +56,7 @@ public class QueryStockLedgerActionBuilder {
             builder = new ActionParameterRequestBuilder()
                     .setDisplayName(DisplayNames.SECTION_ID)
                     .setKey(EventDataKeys.SECTION_ID)
-                    .setType(UNICODE)
+                    .setType(UNICODE.getValue())
                     .setRequired(true)
                     .setOrder(order++);
             parameters.add(builder.createActionParameterRequest());
@@ -63,7 +64,7 @@ public class QueryStockLedgerActionBuilder {
             builder = new ActionParameterRequestBuilder()
                     .setDisplayName(DisplayNames.START_DATE)
                     .setKey(EventDataKeys.START_DATE)
-                    .setType(DATE)
+                    .setType(DATE.getValue())
                     .setRequired(false)
                     .setOrder(order++);
             parameters.add(builder.createActionParameterRequest());
@@ -71,7 +72,15 @@ public class QueryStockLedgerActionBuilder {
             builder = new ActionParameterRequestBuilder()
                     .setDisplayName(DisplayNames.END_DATE)
                     .setKey(EventDataKeys.END_DATE)
-                    .setType(DATE)
+                    .setType(DATE.getValue())
+                    .setRequired(false)
+                    .setOrder(order++);
+            parameters.add(builder.createActionParameterRequest());
+
+            builder = new ActionParameterRequestBuilder()
+                    .setDisplayName(DisplayNames.EXTRA_DATA)
+                    .setKey(EventDataKeys.EXTRA_DATA)
+                    .setType(MAP.getValue())
                     .setRequired(false)
                     .setOrder(order);
             parameters.add(builder.createActionParameterRequest());

--- a/commcare/src/main/java/org/motechproject/commcare/util/CommcareParamHelper.java
+++ b/commcare/src/main/java/org/motechproject/commcare/util/CommcareParamHelper.java
@@ -22,6 +22,24 @@ public final class CommcareParamHelper {
     }
 
     /**
+     * Prints the passed object as a datetime. Supports {@link String} and {@link DateTime} objects.
+     * @param object the object to print
+     * @return the object printed as a datetime, or null if the object was null
+     * @throws IllegalArgumentException if the object is not a supported class
+     */
+    public static String printObjectAsDateTime(Object object) {
+        if (object instanceof DateTime) {
+            return printDateTime((DateTime) object);
+        } else if (object instanceof String) {
+            return (String) object;
+        } else if (object == null) {
+            return null;
+        } else {
+            throw new IllegalArgumentException("Cannot print a datetime from " + object.getClass().getName());
+        }
+    }
+
+    /**
      * Calculates the offset parameter based on the page size and page number.
      * @param pageSize the page size
      * @param pageNumber the page number

--- a/commcare/src/main/resources/webapp/messages/messages.properties
+++ b/commcare/src/main/resources/webapp/messages/messages.properties
@@ -102,6 +102,7 @@ commcare.transactionDate=Transaction Date
 commcare.type=Type
 commcare.startDate=Start Date
 commcare.endDate=End Date
+commcare.extraData=Extra Data
 
 commcare.name=Commcare
 commcare.user.name=User

--- a/commcare/src/test/java/org/motechproject/commcare/it/CommcareTasksIntegrationBundleIT.java
+++ b/commcare/src/test/java/org/motechproject/commcare/it/CommcareTasksIntegrationBundleIT.java
@@ -197,6 +197,7 @@ public class CommcareTasksIntegrationBundleIT extends AbstractTaskBundleIT {
         TaskTriggerInformation expectedForm1 = new TaskTriggerInformation();
         TaskTriggerInformation expectedForm2 = new TaskTriggerInformation();
         TaskTriggerInformation expectedCaseBirth = new TaskTriggerInformation();
+        TaskTriggerInformation expectedStockTx = new TaskTriggerInformation();
 
         expectedForm1.setSubject("org.motechproject.commcare.api.forms." + config.getName() + ".form1");
         assertTrue(channel.containsTrigger(expectedForm1));
@@ -206,6 +207,9 @@ public class CommcareTasksIntegrationBundleIT extends AbstractTaskBundleIT {
 
         expectedCaseBirth.setSubject("org.motechproject.commcare.api.case." + config.getName() + ".birth");
         assertTrue(channel.containsTrigger(expectedCaseBirth));
+
+        expectedStockTx.setSubject(EventSubjects.RECEIVED_STOCK_TRANSACTION + '.' + config.getName());
+        assertTrue(channel.containsTrigger(expectedStockTx));
 
         TriggerEvent form1Trigger = channel.getTrigger(expectedForm1);
         assertEquals("org.motechproject.commcare.api.forms", form1Trigger.getTriggerListenerSubject());
@@ -319,6 +323,14 @@ public class CommcareTasksIntegrationBundleIT extends AbstractTaskBundleIT {
                 .setDisplayName(DisplayNames.END_DATE)
                 .setKey(EventDataKeys.END_DATE)
                 .setType(ParameterType.DATE)
+                .setRequired(false)
+                .setOrder(order++);
+        parameters.add(builder.createActionParameter());
+
+        builder = new ActionParameterBuilder()
+                .setDisplayName(DisplayNames.EXTRA_DATA)
+                .setKey(EventDataKeys.EXTRA_DATA)
+                .setType(ParameterType.MAP)
                 .setRequired(false)
                 .setOrder(order);
         parameters.add(builder.createActionParameter());

--- a/commcare/src/test/java/org/motechproject/commcare/util/CommcareParamHelperTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/util/CommcareParamHelperTest.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CommcareParamHelperTest {
 
@@ -22,5 +23,18 @@ public class CommcareParamHelperTest {
         assertEquals(0, CommcareParamHelper.toOffset(100, 1));
         assertEquals(100, CommcareParamHelper.toOffset(100, 2));
         assertEquals(75, CommcareParamHelper.toOffset(25, 4));
+    }
+
+    @Test
+    public void shouldParaseObjectsToDateTime() {
+        final DateTime dt = new DateTime(2012, 9, 27, 10, 50, 11);
+        assertEquals("2012-09-27T10:50:11", CommcareParamHelper.printObjectAsDateTime(dt));
+        assertEquals("2012-09-27T10:50:11", CommcareParamHelper.printObjectAsDateTime("2012-09-27T10:50:11"));
+        assertNull(CommcareParamHelper.printObjectAsDateTime(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenAttemptintToPrintObjectOfBadClass() {
+        CommcareParamHelper.printObjectAsDateTime(new Object());
     }
 }


### PR DESCRIPTION
- The query stock ledger actions now contains an extra data field,
  which is a map. Everything from this map will be injected into
  events being fired for each retrieved stock.
- This data can be accessed using the notation {{trigger.key}}, where
  key is the key from the extra data map.
