### PR TITLE
Updated motech.version dependency from 0.26.2 to 0.26.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <motech.groupId>org.motechproject</motech.groupId>
-        <motech.version>0.26.2</motech.version>
+        <motech.version>0.26.3-SNAPSHOT</motech.version>
 
         <jasmine.server.port>8234</jasmine.server.port>
 


### PR DESCRIPTION
The Jenkins release process updated all of the module versions from 0.26.2 to 0.26.3-SNAPSHOT, but missed the motech.version property. This change updates the <motech.version> property from 0.26.2 to 0.26.3-SNAPSHOT.

@pgesek Can you take a quick look at the Jenkins release process and include this? 
