### PR TITLE
MOTECH-1936: Added rounding to the display of decimal fields in IVR

### DIFF
--- a/ivr/src/main/java/org/motechproject/ivr/domain/CallDetailRecord.java
+++ b/ivr/src/main/java/org/motechproject/ivr/domain/CallDetailRecord.java
@@ -1,6 +1,7 @@
 package org.motechproject.ivr.domain;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.motechproject.commons.date.util.DateUtil;
@@ -16,7 +17,10 @@ import org.motechproject.mds.util.SecurityMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -299,14 +303,14 @@ public class CallDetailRecord {
      * @return the duration of this call
      */
     public String getCallDuration() {
-        return callDuration;
+        return parseDecimalString(callDuration);
     }
 
     /**
      * @return the percent listened of the message
      */
     public String getMessagePercentListened() {
-        return messagePercentListened;
+        return parseDecimalString(messagePercentListened);
     }
 
     /**
@@ -322,7 +326,7 @@ public class CallDetailRecord {
     public void setField(String key, String val, Map<String, String> callStatusMapping) {
         String value;
 
-        if (val.length() > MAX_ENTITY_STRING_LENGTH) {
+        if (val != null && val.length() > MAX_ENTITY_STRING_LENGTH) {
             LOGGER.warn("The value for {} exceeds {} characters and will be truncated.", key, MAX_ENTITY_STRING_LENGTH);
             LOGGER.warn("The complete value for {} is {}", key, val);
             value = val.substring(0, MAX_ENTITY_STRING_LENGTH);
@@ -463,5 +467,26 @@ public class CallDetailRecord {
                 ", callDuration=" + callDuration +
                 ", messagePercentListened=" + messagePercentListened +
                 '}';
+    }
+
+    private String parseDecimalString(String value) {
+        if (StringUtils.isBlank(value)) {
+            // leave blanks untouched
+            return value;
+        } else {
+            try {
+                // round to two decimal digits
+                double doubleVal = Double.parseDouble(value);
+
+                // always want to use English Locale here
+                DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.ENGLISH);
+                DecimalFormat df = new DecimalFormat("#.##", symbols);
+
+                return df.format(doubleVal);
+            } catch (NumberFormatException e) {
+                // if this is not a number, return what we have
+                return value;
+            }
+        }
     }
 }

--- a/ivr/src/test/java/org/motechproject/ivr/domain/CallDetailRecordTest.java
+++ b/ivr/src/test/java/org/motechproject/ivr/domain/CallDetailRecordTest.java
@@ -1,7 +1,10 @@
 package org.motechproject.ivr.domain;
 
+import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,6 +16,9 @@ import static org.junit.Assert.assertTrue;
  */
 public class CallDetailRecordTest {
 
+    private static final String MESSAGE_PERCENT_LISTENED = "messagePercentListened";
+    private static final String CALL_DURATION = "callDuration";
+
     @Test
     public void shouldSetCallDetailStatus() {
         CallDetailRecord callDetailRecord = new CallDetailRecord();
@@ -23,7 +29,7 @@ public class CallDetailRecordTest {
     @Test
     public void shouldUseCallDetailStatusMapping() {
         CallDetailRecord callDetailRecord = new CallDetailRecord();
-        Map mapping = setUpCallStatusMapping();
+        Map<String, String> mapping = setUpCallStatusMapping();
 
         callDetailRecord.setField("callStatus", "12", mapping);
         assertEquals("Error", callDetailRecord.getCallStatus());
@@ -58,19 +64,53 @@ public class CallDetailRecordTest {
     @Test
     public void shouldSetCallDetailAsProviderExtraData() {
         CallDetailRecord callDetailRecord = new CallDetailRecord();
-        Map mapping = setUpCallStatusMapping();
+        Map<String, String> mapping = setUpCallStatusMapping();
 
         callDetailRecord.setField( "provider-specific-stuff", "specific-value", mapping);
         assertTrue(callDetailRecord.getProviderExtraData().containsKey("provider-specific-stuff"));
         assertEquals("specific-value", callDetailRecord.getProviderExtraData().get("provider-specific-stuff"));
     }
 
-    private Map setUpCallStatusMapping() {
-        Map mapping = new HashMap<String, String>();
+    @Test
+    public void shouldHandleDecimalsProperly() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        Map<String, String> mapping = setUpCallStatusMapping();
+        CallDetailRecord cdr = new CallDetailRecord();
+
+        for (String field : Arrays.asList(MESSAGE_PERCENT_LISTENED, CALL_DURATION)) {
+            cdr.setField(field, null, mapping);
+            assertField(cdr, field, null);
+
+            cdr.setField(field, "", mapping);
+            assertField(cdr, field, "");
+
+            cdr.setField(field, "nonNumber", mapping);
+            assertField(cdr, field, "nonNumber");
+
+            cdr.setField(field, "4.247342", mapping);
+            assertField(cdr, field, "4.25");
+
+            cdr.setField(field, "4.00", mapping);
+            assertField(cdr, field, "4");
+
+            cdr.setField(field, "4.10", mapping);
+            assertField(cdr, field, "4.1");
+
+            cdr.setField(field, "100", mapping);
+            assertField(cdr, field, "100");
+        }
+    }
+
+    private Map<String, String> setUpCallStatusMapping() {
+        Map<String, String> mapping = new HashMap<>();
 
         mapping.put("12", "Error");
         mapping.put("1", "Answered");
 
         return mapping;
+    }
+
+    private void assertField(CallDetailRecord cdr, String field, String expectedValue)
+            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        assertEquals("Field has wrong value: " + field, expectedValue, PropertyUtils.getProperty(cdr, field));
     }
 }


### PR DESCRIPTION
- We round to two decimal points
- We don't display the decimal part if it is equal 0
- If the value is not a number, we leave it as is
