### PR TITLE
MOTECH-1941 Bumped max upload size for CMS Lite

### DIFF
--- a/cms-lite/src/main/resources/META-INF/motech/applicationCmsLiteApi.xml
+++ b/cms-lite/src/main/resources/META-INF/motech/applicationCmsLiteApi.xml
@@ -13,7 +13,7 @@
     <context:component-scan base-package="org.motechproject.cmslite"/>
 
     <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-        <property name="maxUploadSize" value="1000000"/>
+        <property name="maxUploadSize" value="10000000"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
The CMS Lite had rather small maximum upload size,
as for a module that is supposed to store binary objects.
I've raised the max upload size by a factoer of 10.
