### PR TITLE
MOTECH-1960: Fixed SubscriptionServiceImplTest

### DIFF
--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -138,8 +138,8 @@ The Hub module exposes OSGi ``SubscriptionService`` for subscribing:
     }
 
 To subscribe with this service just call subscribe method passing all the parameters. This method returns id of the thread
-which will verify the intent of the subscriber requesting subscription. In case of hubMode is ``unsubscribe`` thread isn't
-created and method returns null. Detailed description of the parameters is shown in table below.
+which will verify the intent of the subscriber requesting subscription. If hubMode is ``unsubscribe`` the thread
+won't be created and the method will return null. Detailed description of the parameters is shown in table below.
 
 Parameters description
 ----------------------

--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -132,13 +132,14 @@ The Hub module exposes OSGi ``SubscriptionService`` for subscribing:
 
     public interface SubscriptionService {
 
-        void subscribe(String callbackUrl, Modes hubMode, String topic,
+        Long subscribe(String callbackUrl, Modes hubMode, String topic,
                 String leaseSeconds, String secret) throws HubException;
 
     }
 
-To subscribe with this service just call subscribe method passing all the parameters. Detailed description of the parameters
-is shown in table below.
+To subscribe with this service just call subscribe method passing all the parameters. This method returns id of the thread
+which will verify the intent of the subscriber requesting subscription. In case of hubMode is ``unsubscribe`` thread isn't
+created and method returns null. Detailed description of the parameters is shown in table below.
 
 Parameters description
 ----------------------

--- a/hub/src/main/java/org/motechproject/hub/service/SubscriptionService.java
+++ b/hub/src/main/java/org/motechproject/hub/service/SubscriptionService.java
@@ -16,8 +16,8 @@ public interface SubscriptionService {
      * This method executes the business logic for subscribing/unsubscribing to
      * a topic. The subscriber provides the callback URL where the update
      * notification should be sent. Returns the id of the IntentVerificationThreadRunnable
-     * thread which verify the intent of the subscriber requesting subscription. In case of hubMode
-     * is "unsubscribe" thread isn't created and method returns null.
+     * thread which verifies the intent of the subscriber requesting subscription. If hubMode
+     * is "unsubscribe" the thread won't be created and the method will return null.
      *
      * @param callbackUrl
      *            - a <code>String</code> representing the subscriber's callback
@@ -36,7 +36,7 @@ public interface SubscriptionService {
      *            - a <code>String</code> provided by the subscriber which will
      *            be used to compute an HMAC digest for authorized content
      *            distribution. Currently this is not being consumed by the API
-     * @return the id of IntentVerificationThreadRunnable which is created, if thread wasn't created then returns null
+     * @return the id of IntentVerificationThreadRunnable which is created, if the thread wasn't created then returns null
      * @throws HubException
      *            - when unsubscribing from a topic that was not subscribed to,
      *            when the topic does not exist or when the topic was not found

--- a/hub/src/main/java/org/motechproject/hub/service/SubscriptionService.java
+++ b/hub/src/main/java/org/motechproject/hub/service/SubscriptionService.java
@@ -15,7 +15,9 @@ public interface SubscriptionService {
     /**
      * This method executes the business logic for subscribing/unsubscribing to
      * a topic. The subscriber provides the callback URL where the update
-     * notification should be sent.
+     * notification should be sent. Returns the id of the IntentVerificationThreadRunnable
+     * thread which verify the intent of the subscriber requesting subscription. In case of hubMode
+     * is "unsubscribe" thread isn't created and method returns null.
      *
      * @param callbackUrl
      *            - a <code>String</code> representing the subscriber's callback
@@ -34,11 +36,12 @@ public interface SubscriptionService {
      *            - a <code>String</code> provided by the subscriber which will
      *            be used to compute an HMAC digest for authorized content
      *            distribution. Currently this is not being consumed by the API
+     * @return the id of IntentVerificationThreadRunnable which is created, if thread wasn't created then returns null
      * @throws HubException
      *            - when unsubscribing from a topic that was not subscribed to,
      *            when the topic does not exist or when the topic was not found
      */
-    void subscribe(String callbackUrl, Modes hubMode, String topic,
+    Long subscribe(String callbackUrl, Modes hubMode, String topic,
             String leaseSeconds, String secret) throws HubException;
 
 }

--- a/hub/src/main/java/org/motechproject/hub/service/impl/SubscriptionServiceImpl.java
+++ b/hub/src/main/java/org/motechproject/hub/service/impl/SubscriptionServiceImpl.java
@@ -27,9 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
-import java.util.List;
-import java.util.UUID;
-
 /**
  * Default implementation of {@link org.motechproject.hub.service.SubscriptionService}
  */
@@ -111,7 +108,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     @Override
     @Transactional
-    public void subscribe(final String callbackUrl, final Modes mode,
+    public Long subscribe(final String callbackUrl, final Modes mode,
             final String topic, String leaseSeconds, String secret)
             throws HubException {
 
@@ -157,7 +154,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
             Thread intentVerifiationThread = new Thread(runnable);
             intentVerifiationThread.start();
-
+            return intentVerifiationThread.getId();
         } else if (mode.equals(Modes.UNSUBSCRIBE)) { // unsubscription request
             if (hubTopic != null) {
                 unsubscribe(hubTopicId, topic, callbackUrl, mode);
@@ -172,7 +169,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 hubTopicService.delete(hubTopic);
             }
         }
-
+        return null;
     }
 
     private void createHubSubscription(String callbackUrl, long topicId,


### PR DESCRIPTION
Now subscribe method returns id of the IntentVerificationThreadRunnable. If thread wasn't created then null is returned.
