### PR TITLE
MOTECH-1939 Fixed DHIS2 request payload and response mapping

### DIFF
--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
@@ -61,7 +61,7 @@ public class EventHandler {
     @MotechListener(subjects = EventSubjects.CREATE_ENTITY)
     public void handleCreate (MotechEvent event) {
         LOGGER.debug("Handling CREATE_ENTITY MotechEvent");
-        Map<String, Object> params = new HashMap<>(event.getParameters());
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
         String externalUUID = (String) params.remove(EventParams.EXTERNAL_ID);
         TrackedEntityInstanceDto trackedEntityInstance = createTrackedEntityInstanceFromParams(params);
 
@@ -69,7 +69,7 @@ public class EventHandler {
         DhisStatusResponse response = dhisWebService.createTrackedEntityInstance(trackedEntityInstance);
 
         LOGGER.trace("Received response from the DHIS server. Status: {}", response.getStatus());
-        if (response.getStatus() == DhisStatus.SUCCESS) {
+        if (response.getStatus() == DhisStatus.SUCCESS || response.getStatus() == DhisStatus.OK) {
             trackedEntityInstanceMappingService.create(externalUUID, response.getReference());
         }
     }
@@ -82,7 +82,7 @@ public class EventHandler {
      */
     @MotechListener(subjects = {EventSubjects.ENROLL_IN_PROGRAM})
     public void handleEnrollment (MotechEvent event) {
-        Map<String, Object> params = new HashMap<>(event.getParameters());
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
         EnrollmentDto enrollment = createEnrollmentFromParams(params);
         dhisWebService.createEnrollment(enrollment);
     }
@@ -96,7 +96,7 @@ public class EventHandler {
      */
     @MotechListener(subjects = {EventSubjects.UPDATE_PROGRAM_STAGE})
     public void handleStageUpdate (MotechEvent event) {
-        Map<String, Object> params = new HashMap<>(event.getParameters());
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
         DhisEventDto dhisEventDto = createDhisEventFromParams(params);
         dhisWebService.createEvent(dhisEventDto);
     }
@@ -110,7 +110,7 @@ public class EventHandler {
      */
     @MotechListener(subjects = {EventSubjects.CREATE_AND_ENROLL})
     public void handleCreateAndEnroll (MotechEvent event) {
-        Map<String, Object> params = new HashMap<>(event.getParameters());
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
         Map<String, Object> enrollmentParams = new HashMap<>();
 
         enrollmentParams.put(EventParams.PROGRAM, params.remove(EventParams.PROGRAM));
@@ -120,6 +120,86 @@ public class EventHandler {
 
         handleCreate(new MotechEvent(EventSubjects.CREATE_ENTITY, params));
         handleEnrollment(new MotechEvent(EventSubjects.ENROLL_IN_PROGRAM, enrollmentParams));
+    }
+
+    /**
+     * Parses the event and creates a{@link org.motechproject.dhis2.rest.domain.DataValueDto}which
+     * is then sent to the DHIS2 server via {@link org.motechproject.dhis2.rest.service.DhisWebService}
+     *
+     * @param event
+     */
+    @MotechListener(subjects = EventSubjects.SEND_DATA_VALUE)
+    public void handleDataValue(MotechEvent event) {
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
+
+        DataElement dataElement = dataElementService.findByName((String) params.get(EventParams.DATA_ELEMENT));
+        String orgUnitId = (String) params.get(EventParams.LOCATION);
+        String period = (String) params.get(EventParams.PERIOD);
+        String value = (String) params.get(EventParams.VALUE);
+        String categoryOptionCombo = (String) params.get(EventParams.CATEGORY_OPTION_COMBO);
+        String comment = (String) params.get(EventParams.COMMENT);
+
+        DataValueDto dataValueDto = new DataValueDto();
+        dataValueDto.setDataElement(dataElement.getUuid());
+        dataValueDto.setValue(value);
+        dataValueDto.setOrgUnit(orgUnitId);
+        dataValueDto.setPeriod(period);
+        dataValueDto.setCategoryOptionCombo(categoryOptionCombo);
+        dataValueDto.setComment(comment);
+
+        DataValueSetDto dataValueSetDto = new DataValueSetDto();
+        List<DataValueDto> dataValueDtos = new ArrayList<>();
+        dataValueDtos.add(dataValueDto);
+        dataValueSetDto.setDataValues(dataValueDtos);
+
+        dhisWebService.sendDataValueSet(dataValueSetDto);
+
+    }
+
+    /**
+     * Parses the event and creates a{@link org.motechproject.dhis2.rest.domain.DataValueSetDto}which
+     * is then sent to the DHIS2 server via {@link org.motechproject.dhis2.rest.service.DhisWebService}
+     *
+     * @param event
+     */
+    @MotechListener(subjects = EventSubjects.SEND_DATA_VALUE_SET)
+    public void handleDataValueSet(MotechEvent event) {
+        Map<String, Object> params = prepareDhisAttributesMap(event.getParameters());
+        String dataSet = (String) params.get(EventParams.DATA_SET);
+        String completeDate = (String) params.get(EventParams.COMPLETE_DATE);
+        String period = (String) params.get(EventParams.PERIOD);
+        String orgUnitId = (String) params.get(EventParams.LOCATION);
+        String categoryOptionCombo = (String) params.get(EventParams.CATEGORY_OPTION_COMBO);
+        String comment = (String) params.get(EventParams.COMMENT);
+        String attributeOptionCombo = (String) params.get(EventParams.ATTRIBUTE_OPTION_COMBO);
+        Map<String, Object> dataValues = (Map<String, Object>) params.get(EventParams.DATA_VALUES);
+
+
+        List<DataValueDto> dataValueDtos = new ArrayList<>();
+
+        for (Object o : dataValues.entrySet()) {
+            Entry pair = (Entry) o;
+            String dataElement = (String) pair.getKey();
+            String dataElementId = dataElementService.findByName(dataElement).getUuid();
+            String value = (String) pair.getValue();
+            DataValueDto dataValueDto = new DataValueDto();
+            dataValueDto.setDataElement(dataElementId);
+            dataValueDto.setValue(value);
+
+            dataValueDtos.add(dataValueDto);
+        }
+
+        DataValueSetDto dataValueSetDto = new DataValueSetDto();
+        dataValueSetDto.setDataSet(dataSet);
+        dataValueSetDto.setPeriod(period);
+        dataValueSetDto.setCompleteDate(completeDate);
+        dataValueSetDto.setOrgUnit(orgUnitId);
+        dataValueSetDto.setDataValues(dataValueDtos);
+        dataValueSetDto.setAttributeOptionCombo(attributeOptionCombo);
+        dataValueSetDto.setCategoryOptionCombo(categoryOptionCombo);
+        dataValueSetDto.setComment(comment);
+        dhisWebService.sendDataValueSet(dataValueSetDto);
+
     }
 
     private TrackedEntityInstanceDto createTrackedEntityInstanceFromParams (Map<String, Object> params) {
@@ -206,84 +286,14 @@ public class EventHandler {
         return dhisEventDto;
     }
 
-    /**
-     * Parses the event and creates a{@link org.motechproject.dhis2.rest.domain.DataValueDto}which
-     * is then sent to the DHIS2 server via {@link org.motechproject.dhis2.rest.service.DhisWebService}
-     *
-     * @param event
-     */
-    @MotechListener(subjects = EventSubjects.SEND_DATA_VALUE)
-    public void handleDataValue(MotechEvent event) {
+    private Map<String, Object> prepareDhisAttributesMap(Map<String, Object> eventParams) {
+        Map<String, Object> dhisAttributes = new HashMap<>(eventParams);
 
-        Map<String, Object> params = event.getParameters();
+        dhisAttributes.remove(MotechEvent.PARAM_INVALID_MOTECH_EVENT);
+        dhisAttributes.remove(MotechEvent.PARAM_REDELIVERY_COUNT);
+        dhisAttributes.remove(EventParams.MESSAGE_DESTINATION);
 
-        DataElement dataElement = dataElementService.findByName((String) params.get(EventParams.DATA_ELEMENT));
-        String orgUnitId = (String) params.get(EventParams.LOCATION);
-        String period = (String) params.get(EventParams.PERIOD);
-        String value = (String) params.get(EventParams.VALUE);
-        String categoryOptionCombo = (String) params.get(EventParams.CATEGORY_OPTION_COMBO);
-        String comment = (String) params.get(EventParams.COMMENT);
-
-        DataValueDto dataValueDto = new DataValueDto();
-        dataValueDto.setDataElement(dataElement.getUuid());
-        dataValueDto.setValue(value);
-        dataValueDto.setOrgUnit(orgUnitId);
-        dataValueDto.setPeriod(period);
-        dataValueDto.setCategoryOptionCombo(categoryOptionCombo);
-        dataValueDto.setComment(comment);
-
-        DataValueSetDto dataValueSetDto = new DataValueSetDto();
-        List<DataValueDto> dataValueDtos = new ArrayList<>();
-        dataValueDtos.add(dataValueDto);
-        dataValueSetDto.setDataValues(dataValueDtos);
-
-        dhisWebService.sendDataValueSet(dataValueSetDto);
-
+        return dhisAttributes;
     }
 
-    /**
-     * Parses the event and creates a{@link org.motechproject.dhis2.rest.domain.DataValueSetDto}which
-     * is then sent to the DHIS2 server via {@link org.motechproject.dhis2.rest.service.DhisWebService}
-     *
-     * @param event
-     */
-    @MotechListener(subjects = EventSubjects.SEND_DATA_VALUE_SET)
-    public void handleDataValueSet(MotechEvent event) {
-        Map<String, Object> params = event.getParameters();
-        String dataSet = (String) params.get(EventParams.DATA_SET);
-        String completeDate = (String) params.get(EventParams.COMPLETE_DATE);
-        String period = (String) params.get(EventParams.PERIOD);
-        String orgUnitId = (String) params.get(EventParams.LOCATION);
-        String categoryOptionCombo = (String) params.get(EventParams.CATEGORY_OPTION_COMBO);
-        String comment = (String) params.get(EventParams.COMMENT);
-        String attributeOptionCombo = (String) params.get(EventParams.ATTRIBUTE_OPTION_COMBO);
-        Map<String, Object> dataValues = (Map<String, Object>) params.get(EventParams.DATA_VALUES);
-
-
-        List<DataValueDto> dataValueDtos = new ArrayList<>();
-
-        for (Object o : dataValues.entrySet()) {
-            Entry pair = (Entry) o;
-            String dataElement = (String) pair.getKey();
-            String dataElementId = dataElementService.findByName(dataElement).getUuid();
-            String value = (String) pair.getValue();
-            DataValueDto dataValueDto = new DataValueDto();
-            dataValueDto.setDataElement(dataElementId);
-            dataValueDto.setValue(value);
-
-            dataValueDtos.add(dataValueDto);
-        }
-
-        DataValueSetDto dataValueSetDto = new DataValueSetDto();
-        dataValueSetDto.setDataSet(dataSet);
-        dataValueSetDto.setPeriod(period);
-        dataValueSetDto.setCompleteDate(completeDate);
-        dataValueSetDto.setOrgUnit(orgUnitId);
-        dataValueSetDto.setDataValues(dataValueDtos);
-        dataValueSetDto.setAttributeOptionCombo(attributeOptionCombo);
-        dataValueSetDto.setCategoryOptionCombo(categoryOptionCombo);
-        dataValueSetDto.setComment(comment);
-        dhisWebService.sendDataValueSet(dataValueSetDto);
-
-    }
 }

--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
@@ -14,6 +14,7 @@ import org.motechproject.dhis2.service.DataElementService;
 import org.motechproject.dhis2.service.TrackedEntityInstanceMappingService;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.annotations.MotechListener;
+import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -292,6 +293,7 @@ public class EventHandler {
         dhisAttributes.remove(MotechEvent.PARAM_INVALID_MOTECH_EVENT);
         dhisAttributes.remove(MotechEvent.PARAM_REDELIVERY_COUNT);
         dhisAttributes.remove(EventParams.MESSAGE_DESTINATION);
+        dhisAttributes.remove(MotechSchedulerService.JOB_ID_KEY);
 
         return dhisAttributes;
     }

--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventParams.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventParams.java
@@ -23,7 +23,5 @@ public final class EventParams {
     public static final String CATEGORY_OPTION_COMBO = "category_option_combo";
     public static final String COMMENT = "comment";
 
-
-
-
+    public static final String MESSAGE_DESTINATION = "message-destination";
 }

--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/DhisStatus.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/DhisStatus.java
@@ -1,6 +1,7 @@
 package org.motechproject.dhis2.rest.domain;
 
-public enum  DhisStatus {
+public enum DhisStatus {
+    OK,
     SUCCESS,
     ERROR
 }

--- a/dhis2/src/test/java/org/motechproject/dhis2/event/EventHandlerTest.java
+++ b/dhis2/src/test/java/org/motechproject/dhis2/event/EventHandlerTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.motechproject.dhis2.domain.OrgUnit;
 import org.motechproject.dhis2.rest.domain.AttributeDto;
 import org.motechproject.dhis2.rest.domain.DataValueDto;
 import org.motechproject.dhis2.rest.domain.DhisEventDto;
@@ -15,7 +14,6 @@ import org.motechproject.dhis2.rest.domain.EnrollmentDto;
 import org.motechproject.dhis2.rest.domain.ImportCountDto;
 import org.motechproject.dhis2.rest.domain.TrackedEntityInstanceDto;
 import org.motechproject.dhis2.rest.service.DhisWebService;
-import org.motechproject.dhis2.service.OrgUnitService;
 import org.motechproject.dhis2.service.SettingsService;
 import org.motechproject.dhis2.service.TrackedEntityInstanceMappingService;
 import org.motechproject.event.MotechEvent;
@@ -57,7 +55,6 @@ public class EventHandlerTest {
 
     @Before
     public void setup() throws Exception{
-
         ImportCountDto importCount = new ImportCountDto();
         importCount.setImported(1);
         importCount.setUpdated(0);
@@ -72,8 +69,7 @@ public class EventHandlerTest {
     }
 
     @Test
-    public void testCreate () throws Exception {
-
+    public void testCreate() throws Exception {
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -85,27 +81,27 @@ public class EventHandlerTest {
         instance.setAttributes(attributeDtos);
         instance.setOrgUnit(ORGUNIT_ID);
 
-
         when(dhisWebservice.createTrackedEntityInstance(instance)).thenReturn(response);
 
         Map<String,Object> params = new HashMap<>();
         params.put(EventParams.EXTERNAL_ID,ENTITY_INSTANCE_ID);
         params.put(EventParams.ENTITY_TYPE, ENTITY_TYPE_PERSON );
-        params.put(EventParams.LOCATION,ORGUNIT_ID);
+        params.put(EventParams.LOCATION, ORGUNIT_ID);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
 
-        MotechEvent event = new MotechEvent(EventSubjects.CREATE_ENTITY,params);
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
+        MotechEvent event = new MotechEvent(EventSubjects.CREATE_ENTITY, params);
 
         handler.handleCreate(event);
-        verify(trackedEntityInstanceMappingService).create(ENTITY_INSTANCE_ID,INSTANCE_DHIS_ID);
+        verify(trackedEntityInstanceMappingService).create(ENTITY_INSTANCE_ID, INSTANCE_DHIS_ID);
         verify(dhisWebservice).createTrackedEntityInstance(instance);
-
     }
 
 
     @Test
     public void testEnrollment() throws Exception {
-
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -129,6 +125,9 @@ public class EventHandlerTest {
         params.put(EventParams.DATE, DATE);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
 
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
         MotechEvent event = new MotechEvent(EventSubjects.ENROLL_IN_PROGRAM,params);
 
         handler.handleEnrollment(event);
@@ -139,7 +138,6 @@ public class EventHandlerTest {
 
     @Test
     public void testEventWithRegistration() throws Exception {
-
         List<DataValueDto> dataValues = new ArrayList<>();
         DataValueDto datavalue = new DataValueDto();
         datavalue.setDataElement(DATA_ELEMENT_ID);
@@ -167,6 +165,9 @@ public class EventHandlerTest {
         params.put(EventParams.STAGE,STAGE_ID);
         params.put(DATA_ELEMENT_ID, DATA_ELEMENT_VALUE);
 
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
         MotechEvent event = new MotechEvent(EventSubjects.UPDATE_PROGRAM_STAGE, params);
         handler.handleStageUpdate(event);
 
@@ -175,8 +176,7 @@ public class EventHandlerTest {
     }
 
     @Test
-    public void testCreateAndEnroll () throws Exception {
-
+    public void testCreateAndEnroll() throws Exception {
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -206,6 +206,9 @@ public class EventHandlerTest {
         params.put(EventParams.PROGRAM,PROGRAM_ID );
         params.put(EventParams.DATE, DATE);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
+
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
 
         MotechEvent event = new MotechEvent(EventSubjects.CREATE_AND_ENROLL, params);
 


### PR DESCRIPTION
The attributes sent to the DHIS2 server were build from the paramters, from the MotechEvent payload, however the DHIS2 server will not accept any attributes, that aren't recognized (created earlier). This caused conflicts when using event handlers in DHIS2. The MotechEvent-specific parameters are now removed before attributes are created.
