### PR TITLE
MOTECH-1939 Fixed DHIS2 request payload and response mapping

### DIFF
--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
@@ -150,6 +150,13 @@ public class EventHandler {
         dataValueDto.setPeriod(period);
         dataValueDto.setCategoryOptionCombo(categoryOptionCombo);
         dataValueDto.setComment(comment);
+
+        DataValueSetDto dataValueSetDto = new DataValueSetDto();
+        List<DataValueDto> dataValueDtos = new ArrayList<>();
+        dataValueDtos.add(dataValueDto);
+        dataValueSetDto.setDataValues(dataValueDtos);
+
+        dhisWebService.sendDataValueSet(dataValueSetDto);
     }
 
     /**

--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventHandler.java
@@ -15,6 +15,7 @@ import org.motechproject.dhis2.service.DataElementService;
 import org.motechproject.dhis2.service.TrackedEntityInstanceMappingService;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.annotations.MotechListener;
+import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -295,6 +296,7 @@ public class EventHandler {
         dhisAttributes.remove(MotechEvent.PARAM_INVALID_MOTECH_EVENT);
         dhisAttributes.remove(MotechEvent.PARAM_REDELIVERY_COUNT);
         dhisAttributes.remove(EventParams.MESSAGE_DESTINATION);
+        dhisAttributes.remove(MotechSchedulerService.JOB_ID_KEY);
 
         return dhisAttributes;
     }

--- a/dhis2/src/main/java/org/motechproject/dhis2/event/EventParams.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/event/EventParams.java
@@ -23,7 +23,5 @@ public final class EventParams {
     public static final String CATEGORY_OPTION_COMBO = "category_option_combo";
     public static final String COMMENT = "comment";
 
-
-
-
+    public static final String MESSAGE_DESTINATION = "message-destination";
 }

--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/DhisStatus.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/DhisStatus.java
@@ -1,6 +1,7 @@
 package org.motechproject.dhis2.rest.domain;
 
-public enum  DhisStatus {
+public enum DhisStatus {
+    OK,
     SUCCESS,
     ERROR
 }

--- a/dhis2/src/test/java/org/motechproject/dhis2/event/EventHandlerTest.java
+++ b/dhis2/src/test/java/org/motechproject/dhis2/event/EventHandlerTest.java
@@ -67,7 +67,6 @@ public class EventHandlerTest {
 
     @Before
     public void setup() throws Exception{
-
         ImportCountDto importCount = new ImportCountDto();
         importCount.setImported(1);
         importCount.setUpdated(0);
@@ -81,8 +80,7 @@ public class EventHandlerTest {
     }
 
     @Test
-    public void testCreate () throws Exception {
-
+    public void testCreate() throws Exception {
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -94,27 +92,27 @@ public class EventHandlerTest {
         instance.setAttributes(attributeDtos);
         instance.setOrgUnit(ORGUNIT_ID);
 
-
         when(dhisWebservice.createTrackedEntityInstance(instance)).thenReturn(response);
 
         Map<String,Object> params = new HashMap<>();
         params.put(EventParams.EXTERNAL_ID,ENTITY_INSTANCE_ID);
         params.put(EventParams.ENTITY_TYPE, ENTITY_TYPE_PERSON );
-        params.put(EventParams.LOCATION,ORGUNIT_ID);
+        params.put(EventParams.LOCATION, ORGUNIT_ID);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
 
-        MotechEvent event = new MotechEvent(EventSubjects.CREATE_ENTITY,params);
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
+        MotechEvent event = new MotechEvent(EventSubjects.CREATE_ENTITY, params);
 
         handler.handleCreate(event);
-        verify(trackedEntityInstanceMappingService).create(ENTITY_INSTANCE_ID,INSTANCE_DHIS_ID);
+        verify(trackedEntityInstanceMappingService).create(ENTITY_INSTANCE_ID, INSTANCE_DHIS_ID);
         verify(dhisWebservice).createTrackedEntityInstance(instance);
-
     }
 
 
     @Test
     public void testEnrollment() throws Exception {
-
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -138,6 +136,9 @@ public class EventHandlerTest {
         params.put(EventParams.DATE, DATE);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
 
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
         MotechEvent event = new MotechEvent(EventSubjects.ENROLL_IN_PROGRAM,params);
 
         handler.handleEnrollment(event);
@@ -148,7 +149,6 @@ public class EventHandlerTest {
 
     @Test
     public void testEventWithRegistration() throws Exception {
-
         List<DataValueDto> dataValues = new ArrayList<>();
         DataValueDto datavalue = new DataValueDto();
         datavalue.setDataElement(DATA_ELEMENT_ID);
@@ -176,6 +176,9 @@ public class EventHandlerTest {
         params.put(EventParams.STAGE,STAGE_ID);
         params.put(DATA_ELEMENT_ID, DATA_ELEMENT_VALUE);
 
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
+
         MotechEvent event = new MotechEvent(EventSubjects.UPDATE_PROGRAM_STAGE, params);
         handler.handleStageUpdate(event);
 
@@ -184,8 +187,7 @@ public class EventHandlerTest {
     }
 
     @Test
-    public void testCreateAndEnroll () throws Exception {
-
+    public void testCreateAndEnroll() throws Exception {
         List<AttributeDto> attributeDtos = new ArrayList<>();
         AttributeDto dto = new AttributeDto();
         dto.setAttribute(ATTRIBUTE_ID);
@@ -215,6 +217,9 @@ public class EventHandlerTest {
         params.put(EventParams.PROGRAM,PROGRAM_ID );
         params.put(EventParams.DATE, DATE);
         params.put(ATTRIBUTE_ID, ATTRIBUTE_VALUE);
+
+        // This is always added by the MOTECH Event module and should not get added to tracked entity attributes
+        params.put(EventParams.MESSAGE_DESTINATION, "org.motechproject.dhis2.event.EventHandler:eventHandler");
 
         MotechEvent event = new MotechEvent(EventSubjects.CREATE_AND_ENROLL, params);
 


### PR DESCRIPTION
The attributes sent to the DHIS2 server were build from the paramters, from the MotechEvent payload, however the DHIS2 server will not accept any attributes, that aren't recognized (created earlier). This caused conflicts when using event handlers in DHIS2. The MotechEvent-specific parameters are now removed before attributes are created.
