### PR TITLE
MOTECH-2076: CommCare module task triggers depend on xmlns

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/domain/FormSchemaJson.java
+++ b/commcare/src/main/java/org/motechproject/commcare/domain/FormSchemaJson.java
@@ -23,6 +23,10 @@ public class FormSchemaJson implements Serializable {
     @SerializedName("questions")
     private List<FormSchemaQuestionJson> questions;
 
+    @Expose
+    @SerializedName("xmlns")
+    private String xmlns;
+
     public Map<String, String> getFormNames() {
         return formNames;
     }
@@ -37,6 +41,14 @@ public class FormSchemaJson implements Serializable {
 
     public void setQuestions(List<FormSchemaQuestionJson> questions) {
         this.questions = questions;
+    }
+
+    public String getXmlns() {
+        return xmlns;
+    }
+
+    public void setXmlns(String xmlns) {
+        this.xmlns = xmlns;
     }
 
     /**

--- a/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareFormsEventParser.java
+++ b/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareFormsEventParser.java
@@ -50,8 +50,8 @@ public class CommcareFormsEventParser implements TasksEventParser {
         String configName = (String) eventParameters.get("configName");
 
         if (eventSubject.equals(FORMS_EVENT)) {
-            String formName = (String) ((Map) eventParameters.get(ATTRIBUTES)).get("name");
-            return eventSubject.concat(".").concat(configName).concat(".").concat(formName);
+            String xmlns = (String) ((Map) eventParameters.get(ATTRIBUTES)).get("xmlns");
+            return eventSubject.concat(".").concat(configName).concat(".").concat(xmlns);
         }
 
         return eventSubject.concat(".").concat(configName);

--- a/commcare/src/main/java/org/motechproject/commcare/tasks/builder/FormTriggerBuilder.java
+++ b/commcare/src/main/java/org/motechproject/commcare/tasks/builder/FormTriggerBuilder.java
@@ -65,7 +65,7 @@ public class FormTriggerBuilder implements TriggerBuilder {
 
                 String displayName = DisplayNameHelper.buildDisplayName(RECEIVED_FORM, formName, config.getName());
 
-                triggers.add(new TriggerEventRequest(displayName, FORMS_EVENT + "." + config.getName() + "." + formName,
+                triggers.add(new TriggerEventRequest(displayName, FORMS_EVENT + "." + config.getName() + "." + form.getXmlns(),
                         null, parameters, FORMS_EVENT));
             }
         }

--- a/commcare/src/test/java/org/motechproject/commcare/it/CommcareTasksIntegrationBundleIT.java
+++ b/commcare/src/test/java/org/motechproject/commcare/it/CommcareTasksIntegrationBundleIT.java
@@ -169,7 +169,7 @@ public class CommcareTasksIntegrationBundleIT extends AbstractTaskBundleIT {
 
     private void createTestTask() {
         TaskTriggerInformation triggerInformation = new TaskTriggerInformation("trigger", COMMCARE_CHANNEL_NAME, COMMCARE_CHANNEL_NAME, VERSION,
-                "org.motechproject.commcare.api.forms." + config.getName() + ".form1", "org.motechproject.commcare.api.forms");
+                "org.motechproject.commcare.api.forms." + config.getName() + "." + DummyCommcareSchema.XMLNS1, "org.motechproject.commcare.api.forms");
 
         TaskActionInformation actionInformation = new TaskActionInformation("action", COMMCARE_CHANNEL_NAME, COMMCARE_CHANNEL_NAME, VERSION,
                 TEST_INTERFACE, "execute");
@@ -199,10 +199,10 @@ public class CommcareTasksIntegrationBundleIT extends AbstractTaskBundleIT {
         TaskTriggerInformation expectedCaseBirth = new TaskTriggerInformation();
         TaskTriggerInformation expectedStockTx = new TaskTriggerInformation();
 
-        expectedForm1.setSubject("org.motechproject.commcare.api.forms." + config.getName() + ".form1");
+        expectedForm1.setSubject("org.motechproject.commcare.api.forms." + config.getName() + "." + DummyCommcareSchema.XMLNS1);
         assertTrue(channel.containsTrigger(expectedForm1));
 
-        expectedForm2.setSubject("org.motechproject.commcare.api.forms." + config.getName() + ".form2");
+        expectedForm2.setSubject("org.motechproject.commcare.api.forms." + config.getName() + "." + DummyCommcareSchema.XMLNS2);
         assertTrue(channel.containsTrigger(expectedForm2));
 
         expectedCaseBirth.setSubject("org.motechproject.commcare.api.case." + config.getName() + ".birth");

--- a/commcare/src/test/java/org/motechproject/commcare/service/impl/parser/CommcareEventParsersTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/service/impl/parser/CommcareEventParsersTest.java
@@ -11,6 +11,7 @@ import org.motechproject.commcare.service.CommcareConfigService;
 import org.motechproject.commcare.service.impl.CommcareCaseEventParser;
 import org.motechproject.commcare.service.impl.CommcareFormsEventParser;
 import org.motechproject.commcare.util.ConfigsUtils;
+import org.motechproject.commcare.util.DummyCommcareSchema;
 import org.motechproject.commcare.util.ResponseXML;
 import org.motechproject.commcare.web.CasesController;
 import org.motechproject.commcare.web.FullFormController;
@@ -89,7 +90,7 @@ public class CommcareEventParsersTest {
         String parsedSubject = formsEventParser.parseEventSubject(eventSubject, eventParameters);
 
         assertEquals(EventSubjects.FORMS_EVENT, eventSubject);
-        assertEquals(EventSubjects.FORMS_EVENT + "." + config.getName() + "." + ResponseXML.FORM_NAME, parsedSubject);
+        assertEquals(EventSubjects.FORMS_EVENT + "." + config.getName() + "." + DummyCommcareSchema.XMLNS1, parsedSubject);
     }
 
     @Test

--- a/commcare/src/test/java/org/motechproject/commcare/tasks/builder/FormTriggerBuilderTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/tasks/builder/FormTriggerBuilderTest.java
@@ -25,6 +25,8 @@ import static org.motechproject.commcare.util.DummyCommcareSchema.FORM_QUESTION2
 import static org.motechproject.commcare.util.DummyCommcareSchema.FORM_QUESTION3;
 import static org.motechproject.commcare.util.DummyCommcareSchema.FORM_QUESTION4;
 import static org.motechproject.commcare.util.DummyCommcareSchema.FORM_QUESTION5;
+import static org.motechproject.commcare.util.DummyCommcareSchema.XMLNS1;
+import static org.motechproject.commcare.util.DummyCommcareSchema.XMLNS2;
 
 public class FormTriggerBuilderTest {
 
@@ -39,6 +41,7 @@ public class FormTriggerBuilderTest {
     private FormTriggerBuilder formTriggerBuilder;
 
     private static final int FORM_PREDEFINED_FIELDS = 11;
+    private static final String BASE_SUBJECT = "org.motechproject.commcare.api.forms.ConfigOne";
 
     @Before
     public void setUp() {
@@ -63,13 +66,13 @@ public class FormTriggerBuilderTest {
 
             String subject = request.getSubject();
             switch (subject) {
-                case "org.motechproject.commcare.api.forms.ConfigOne.form1":
+                case BASE_SUBJECT + "." + XMLNS1:
                     assertEquals(2 + FORM_PREDEFINED_FIELDS, request.getEventParameters().size());
                     assertEquals("Received Form: form1 [ConfigOne]", request.getDisplayName());
                     assertTrue(hasEventKey(request.getEventParameters(), FORM_QUESTION1));
                     assertTrue(hasEventKey(request.getEventParameters(), FORM_QUESTION2));
                     break;
-                case "org.motechproject.commcare.api.forms.ConfigOne.form2":
+                case BASE_SUBJECT + "." + XMLNS2:
                     assertEquals(3 + FORM_PREDEFINED_FIELDS, request.getEventParameters().size());
                     assertEquals("Received Form: form2 [ConfigOne]", request.getDisplayName());
                     assertTrue(hasEventKey(request.getEventParameters(), FORM_QUESTION3));

--- a/commcare/src/test/java/org/motechproject/commcare/util/DummyCommcareSchema.java
+++ b/commcare/src/test/java/org/motechproject/commcare/util/DummyCommcareSchema.java
@@ -25,6 +25,9 @@ public final class DummyCommcareSchema {
     public static final String CASE_FIELD4 = "visitDate";
     public static final String CASE_FIELD5 = "isPregnant";
 
+    public static final String XMLNS1 = "http://openrosa.org/formdesigner/84FA38A2-93C1-4B9E-AA2A-0E082995FF9E";
+    public static final String XMLNS2 = "http://openrosa.org/formdesigner/12KE58A2-54C5-1Z4B-AR2S-Z0345995RF9E";
+
     public static List<FormSchemaJson> getForms() {
         List<FormSchemaJson> forms = new ArrayList<>();
 
@@ -56,10 +59,12 @@ public final class DummyCommcareSchema {
         FormSchemaJson formSchemaJson1 = new FormSchemaJson();
         formSchemaJson1.setFormNames(formNames1);
         formSchemaJson1.setQuestions(Arrays.asList(questionJson1, questionJson2));
+        formSchemaJson1.setXmlns(XMLNS1);
 
         FormSchemaJson formSchemaJson2 = new FormSchemaJson();
         formSchemaJson2.setFormNames(formNames2);
         formSchemaJson2.setQuestions(Arrays.asList(questionJson3, questionJson4, questionJson5));
+        formSchemaJson2.setXmlns(XMLNS2);
 
         forms.add(formSchemaJson1);
         forms.add(formSchemaJson2);

--- a/commcare/src/test/java/org/motechproject/commcare/util/ResponseXML.java
+++ b/commcare/src/test/java/org/motechproject/commcare/util/ResponseXML.java
@@ -19,7 +19,7 @@ public final class ResponseXML {
                 "      version=\"41\"\n" +
                 "      name=\"" + FORM_NAME + "\"\n" +
                 "      xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\"\n" +
-                "      xmlns=\"http://openrosa.org/formdesigner/84FA38A2-93C1-4B9E-AA2A-0E082995FF9E\">\n" +
+                "      xmlns=\"" + DummyCommcareSchema.XMLNS1 + "\">\n" +
                 "  <" + ATTR1 + ">" + ATTR1_VALUE + "</" + ATTR1 + ">\n" +
                 "  <" + ATTR2 + ">" + ATTR2_VALUE + "</" + ATTR2 + ">\n" +
                 "  <n0:case case_id=\"" + CASE_ID + "\"\n" +


### PR DESCRIPTION
Previously the CommCare module relied on the form name to determine when to
trigger a task. Now it relies on xmlns. The event subject will look like the
following :
org.motechproject.commcare.api.forms + configName + formXMLNS

For the end user nothing changes, the display names for task triggers are the
same and depend on form name.
