### PR TITLE
MOTECH-2172: Fixed data forwarding rule handling

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareConfigServiceImpl.java
+++ b/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareConfigServiceImpl.java
@@ -259,7 +259,8 @@ public class CommcareConfigServiceImpl implements CommcareConfigService {
 
     private void updateCasesForwarding(Config config, List<String> endpoints) {
         if (config.isForwardCases() && !endpoints.contains(FORWARD_CASE_TYPE)) {
-            forward(config, FORWARD_CASE_TYPE, getCasesUrl(config.getName()));
+            boolean result = forward(config, FORWARD_CASE_TYPE, getCasesUrl(config.getName()));
+            config.setForwardCases(result);
         } else if (!config.isForwardCases() && endpoints.contains(FORWARD_CASE_TYPE)) {
             config.setForwardCases(true);
         }
@@ -267,7 +268,8 @@ public class CommcareConfigServiceImpl implements CommcareConfigService {
 
     private void updateFormsForwarding(Config config, List<String> endpoints) {
         if (config.isForwardForms() && !endpoints.contains(FORWARD_FORMS_TYPE)) {
-            forward(config, FORWARD_FORMS_TYPE, getFormsUrl(config.getName()));
+            boolean result = forward(config, FORWARD_FORMS_TYPE, getFormsUrl(config.getName()));
+            config.setForwardForms(result);
         } else if (!config.isForwardForms() && endpoints.contains(FORWARD_FORMS_TYPE)) {
             config.setForwardForms(true);
         }
@@ -275,7 +277,8 @@ public class CommcareConfigServiceImpl implements CommcareConfigService {
 
     private void updateStubsForwading(Config config, List<String> endpoints) {
         if (config.isForwardStubs() && !endpoints.contains(FORWARD_STUBS_TYPE)) {
-            forward(config, FORWARD_STUBS_TYPE, getFormStubsUrl(config.getName()));
+            boolean result = forward(config, FORWARD_STUBS_TYPE, getFormStubsUrl(config.getName()));
+            config.setForwardStubs(result);
         } else if (!config.isForwardStubs() && endpoints.contains(FORWARD_STUBS_TYPE)) {
             config.setForwardStubs(true);
         }
@@ -283,18 +286,19 @@ public class CommcareConfigServiceImpl implements CommcareConfigService {
 
     private void updateSchemaForwarding(Config config, List<String> endpoints) {
         if (config.isForwardSchema() && !endpoints.contains(FORWARD_SCHEMA_TYPE)) {
-            forward(config, FORWARD_SCHEMA_TYPE, getSchemaChangeUrl(config.getName()));
+            boolean result = forward(config, FORWARD_SCHEMA_TYPE, getSchemaChangeUrl(config.getName()));
+            config.setForwardSchema(result);
         } else if (!config.isForwardSchema() && endpoints.contains(FORWARD_SCHEMA_TYPE)) {
             config.setForwardSchema(true);
         }
     }
 
-    private void forward(Config config, String type, String url) {
+    private boolean forward(Config config, String type, String url) {
         CommcareDataForwardingEndpoint newForwardingEndpoint = new CommcareDataForwardingEndpoint(
                 config.getAccountConfig().getDomain(), type,
                 url, null);
 
-        forwardingEndpointService.createNewDataForwardingRule(newForwardingEndpoint, config);
+        return forwardingEndpointService.createNewDataForwardingRule(newForwardingEndpoint, config);
     }
 
     private String getCasesUrl(String name) {

--- a/commcare/src/main/resources/webapp/js/controllers.js
+++ b/commcare/src/main/resources/webapp/js/controllers.js
@@ -368,7 +368,6 @@
                     $scope.verifyErrorMessage = response.data;
                     $scope.verifySuccessMessage = '';
                     $scope.connectionVerified = false;
-                    $('.commcare .switch-small').bootstrapSwitch('setActive', false);
                     unblockUI();
                 });
         };


### PR DESCRIPTION
- Saving config won't fall apart if the user doesn't have access to
  the forwarding config, which was the root of the error
- If forwarding rules fail to change, this will be reflected on the UI
  (albeit this can still use some improvement)
- Fixed a js bug with failure handling in the verify method (leftover
  code)
