### PR TITLE
MOTECH-2161: Adds getEncounterByUuid lookup

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSEncounter.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSEncounter.java
@@ -13,6 +13,7 @@ import java.util.Set;
 public class OpenMRSEncounter {
 
     private String id;
+    private String display;
     private OpenMRSProvider provider;
     private OpenMRSUser creator;
     private OpenMRSFacility facility;
@@ -50,6 +51,10 @@ public class OpenMRSEncounter {
         this.patient = patient;
         this.observations = observations;
         this.encounterType = encounterType;
+    }
+
+    public String getDisplay() {
+        return display;
     }
 
     public OpenMRSUser getCreator() {
@@ -98,6 +103,7 @@ public class OpenMRSEncounter {
     }
 
     public static class OpenMRSEncounterBuilder {
+        private String display;
         private OpenMRSProvider provider;
         private OpenMRSUser creator;
         private OpenMRSFacility facility;
@@ -106,6 +112,11 @@ public class OpenMRSEncounter {
         private Set<? extends OpenMRSObservation> observations;
         private String encounterType;
         private String id;
+
+        public OpenMRSEncounterBuilder withDisplay(String display) {
+            this.display = display;
+            return this;
+        }
 
         public OpenMRSEncounterBuilder withProvider(OpenMRSProvider provider) {
             this.provider = provider;
@@ -170,6 +181,7 @@ public class OpenMRSEncounter {
 
         public OpenMRSEncounter build() {
             OpenMRSEncounter mrsEncounter = new OpenMRSEncounter(provider, creator, facility, date, patient, observations, encounterType);
+            mrsEncounter.display = this.display;
             mrsEncounter.id = this.id;
             return mrsEncounter;
         }
@@ -181,6 +193,10 @@ public class OpenMRSEncounter {
 
     public void setEncounterId(String encounterId) {
         this.id = encounterId;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public void setProvider(OpenMRSProvider provider) {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSFacility.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSFacility.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 public class OpenMRSFacility {
 
     private String id;
+    private String display;
     private String name;
     private String country;
     private String region;
@@ -21,7 +22,7 @@ public class OpenMRSFacility {
      * @param id  the ID of the facility
      */
     public OpenMRSFacility(String id) {
-        this(id, null, null, null, null, null);
+        this(id, null, null, null, null, null, null);
     }
 
     /**
@@ -35,27 +36,33 @@ public class OpenMRSFacility {
      * @param stateProvince  the name of the state/province where the facility is placed
      */
     public OpenMRSFacility(String name, String country, String region, String countyDistrict, String stateProvince) {
-        this(null, name, country, region, countyDistrict, stateProvince);
+        this(null, null, name, country, region, countyDistrict, stateProvince);
     }
 
     /**
-     * Creates a facility with the given {@code name} and {@code id} that is placed in the given {@code country},
+     * Creates a facility with the given {@code name}, {@code display} and {@code id} that is placed in the given {@code country},
      * {@code region}, {@code countryDistrict} and {@code stateProvince}.
      *
      * @param id  the ID of the facility
+     * @param display  the display of the facility
      * @param name  the name of the facility
      * @param country  the name of the country where the facility is placed
      * @param region  the name of the region where the facility is placed
      * @param countyDistrict  the name of the county/district where the facility is placed
      * @param stateProvince  the name of the state/province where the facility is placed
      */
-    public OpenMRSFacility(String id, String name, String country, String region, String countyDistrict, String stateProvince) {
+    public OpenMRSFacility(String id, String display, String name, String country, String region, String countyDistrict, String stateProvince) {
+        this.id = id;
+        this.display = display;
         this.name = name;
         this.country = country;
         this.region = region;
         this.countyDistrict = countyDistrict;
         this.stateProvince = stateProvince;
-        this.id = id;
+    }
+
+    public String getDisplay() {
+        return display;
     }
 
     public String getName() {
@@ -86,6 +93,10 @@ public class OpenMRSFacility {
     @Deprecated
     public void setId(String id) {
         this.id = id;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public void setName(String name) {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  */
 public class OpenMRSPatient {
 
-    private String id;
+    private String patientId;
     private OpenMRSFacility facility;
     private OpenMRSPerson person;
     private String motechId;
@@ -17,12 +17,12 @@ public class OpenMRSPatient {
     }
 
     /**
-     * Creates a patient with the given OpenMRS {@code id}.
+     * Creates a patient with the given OpenMRS {@code patientId}.
      *
-     * @param id  the OpenMRS ID of the patient
+     * @param patientId  the OpenMRS ID of the patient
      */
-    public OpenMRSPatient(String id) {
-        this(id, null, null, null);
+    public OpenMRSPatient(String patientId) {
+        this(patientId, null, null, null);
     }
 
     /**
@@ -38,23 +38,23 @@ public class OpenMRSPatient {
     }
 
     /**
-     * Creates a patient with the given {@code motechId} and OpenMRS {@code id} based on the given {@code person}
+     * Creates a patient with the given {@code motechId} and OpenMRS {@code patientId} based on the given {@code person}
      * details and assigns it to the given {@code facility}.
      *
-     * @param id  the OpenMRS ID of the patient
+     * @param patientId  the OpenMRS ID of the patient
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
      */
-    public OpenMRSPatient(String id, String motechId, OpenMRSPerson person, OpenMRSFacility facility) {
+    public OpenMRSPatient(String patientId, String motechId, OpenMRSPerson person, OpenMRSFacility facility) {
         this.facility = facility;
         this.person = person;
         this.motechId = motechId;
-        this.id = id;
+        this.patientId = patientId;
     }
 
     public String getPatientId() {
-        return id;
+        return patientId;
     }
 
     public OpenMRSFacility getFacility() {
@@ -81,21 +81,21 @@ public class OpenMRSPatient {
 
         OpenMRSPatient that = (OpenMRSPatient) o;
 
-        return Objects.equals(facility, that.facility) && Objects.equals(id, that.id) &&
+        return Objects.equals(facility, that.facility) && Objects.equals(patientId, that.patientId) &&
                 Objects.equals(motechId, that.motechId) && Objects.equals(person, that.person);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
+        int result = patientId != null ? patientId.hashCode() : 0;
         result = 31 * result + (facility != null ? facility.hashCode() : 0);
         result = 31 * result + (person != null ? person.hashCode() : 0);
         result = 31 * result + (motechId != null ? motechId.hashCode() : 0);
         return result;
     }
 
-    public void setPatientId(String id) {
-        this.id = id;
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
     }
 
     public void setFacility(OpenMRSFacility facility) {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Encounter.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Encounter.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class Encounter {
 
     private String uuid;
+    private String display;
     private Location location;
     private EncounterType encounterType;
     private Date encounterDatetime;
@@ -30,6 +31,14 @@ public class Encounter {
 
     public void setUuid(String uuid) {
         this.uuid = uuid;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public Location getLocation() {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Location.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Location.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Type;
 public class Location {
 
     private String uuid;
+    private String display;
     private String name;
     private String stateProvince;
     private String country;
@@ -27,6 +28,14 @@ public class Location {
 
     public void setUuid(String uuid) {
         this.uuid = uuid;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public String getName() {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSEncounterServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSEncounterServiceImpl.java
@@ -239,7 +239,8 @@ public class OpenMRSEncounterServiceImpl implements OpenMRSEncounterService {
 
     private OpenMRSEncounter convertToMrsEncounter(Encounter encounter, OpenMRSProvider mrsPerson, OpenMRSPatient patient) {
 
-        return new OpenMRSEncounter.OpenMRSEncounterBuilder().withId(encounter.getUuid()).withProvider(mrsPerson)
+        return new OpenMRSEncounter.OpenMRSEncounterBuilder().withId(encounter.getUuid())
+                .withDisplay(encounter.getDisplay()).withProvider(mrsPerson)
                 .withFacility(ConverterUtils.toOpenMRSFacility(encounter.getLocation()))
                 .withDate(encounter.getEncounterDatetime()).withPatient(patient)
                 .withObservations(convertToMrsObservation(encounter.getObs()))

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProvider.java
@@ -1,7 +1,9 @@
 package org.motechproject.openmrs19.tasks;
 
 import org.motechproject.commons.api.AbstractDataProvider;
+import org.motechproject.openmrs19.domain.OpenMRSEncounter;
 import org.motechproject.openmrs19.domain.OpenMRSProvider;
+import org.motechproject.openmrs19.service.OpenMRSEncounterService;
 import org.motechproject.openmrs19.service.OpenMRSProviderService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.BY_UUID;
+import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.ENCOUNTER;
 import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.NAME;
 import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.PACKAGE_ROOT;
 import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.PROVIDER;
@@ -27,17 +30,20 @@ import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.UUID;
 @Service("openMRSTaskDataProvider")
 public class OpenMRSTaskDataProvider extends AbstractDataProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenMRSTaskDataProvider.class);
-    private static final List<Class<?>> SUPPORTED_CLASSES = Arrays.asList(OpenMRSProvider.class);
+    private static final List<Class<?>> SUPPORTED_CLASSES = Arrays.asList(OpenMRSProvider.class, OpenMRSEncounter.class);
 
+    private OpenMRSEncounterService encounterService;
     private OpenMRSProviderService providerService;
 
     @Autowired
-    public OpenMRSTaskDataProvider(ResourceLoader resourceLoader, OpenMRSProviderService providerService) {
+    public OpenMRSTaskDataProvider(ResourceLoader resourceLoader, OpenMRSEncounterService encounterService,
+                                   OpenMRSProviderService providerService) {
         Resource resource = resourceLoader.getResource("task-data-provider.json");
         if (resource != null) {
             setBody(resource);
         }
 
+        this.encounterService = encounterService;
         this.providerService = providerService;
     }
 
@@ -60,15 +66,30 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
     public Object lookup(String type, String lookupName, Map<String, String> lookupFields) {
         Object obj = null;
 
-        //In case of any trouble with the type, method supports logs an error
+        //In case of any trouble with the type, 'supports' method logs an error
         if (supports(type)) {
             switch (type) {
+                case ENCOUNTER: obj = getEncounter(lookupName, lookupFields);
+                    break;
                 case PROVIDER: obj = getProvider(lookupName, lookupFields);
                     break;
             }
         }
 
         return obj;
+    }
+
+    private OpenMRSEncounter getEncounter(String lookupName, Map<String, String> lookupFields) {
+        OpenMRSEncounter encounter = null;
+
+        switch (lookupName) {
+            case BY_UUID: encounter = encounterService.getEncounterByUuid(lookupFields.get(UUID));
+                break;
+            default: LOGGER.error("Lookup with name {} doesn't exist for encounter object", lookupName);
+                break;
+        }
+
+        return encounter;
     }
 
     private OpenMRSProvider getProvider(String lookupName, Map<String, String> lookupFields) {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTasksConstants.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTasksConstants.java
@@ -11,6 +11,7 @@ public final class OpenMRSTasksConstants {
     public static final String BY_UUID = "openMRS.lookup.uuid";
 
     // Lookup objects
+    public static final String ENCOUNTER = "OpenMRSEncounter";
     public static final String PROVIDER = "OpenMRSProvider";
 
     // Field names

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
@@ -140,8 +140,8 @@ public final class ConverterUtils {
      * @return the location converted to the MOTECH model of the facility used by this module
      */
     public static OpenMRSFacility toOpenMRSFacility(Location location) {
-        return new OpenMRSFacility(location.getUuid(), location.getName(), location.getCountry(), location.getAddress6(),
-                location.getCountyDistrict(), location.getStateProvince());
+        return new OpenMRSFacility(location.getUuid(), location.getDisplay(), location.getName(),
+                location.getCountry(), location.getAddress6(), location.getCountyDistrict(), location.getStateProvince());
     }
 
     /**

--- a/openmrs-19/src/main/resources/task-data-provider.json
+++ b/openmrs-19/src/main/resources/task-data-provider.json
@@ -14,7 +14,7 @@
       ],
       "fields": [
         {
-          "displayName": "openMRS.provider.providerId",
+          "displayName": "openMRS.provider.id",
           "fieldKey": "providerId"
         },
         {
@@ -28,6 +28,61 @@
         {
           "displayName": "openMRS.person.display",
           "fieldKey": "person.display"
+        }
+      ]
+    },
+    {
+      "displayName": "openMRS.encounter",
+      "type": "OpenMRSEncounter",
+      "lookupFields": [
+        {
+          "displayName": "openMRS.lookup.uuid",
+          "fields": [
+            "openMRS.uuid"
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "displayName": "openMRS.encounter.id",
+          "fieldKey": "id"
+        },
+        {
+          "displayName": "openMRS.encounter.display",
+          "fieldKey": "display"
+        },
+        {
+          "displayName": "openMRS.encounter.date",
+          "fieldKey": "date",
+          "type": "DATE"
+        },
+        {
+          "displayName": "openMRS.encounter.type",
+          "fieldKey": "encounterType"
+        },
+        {
+          "displayName": "openMRS.provider.id",
+          "fieldKey": "provider.providerId"
+        },
+        {
+          "displayName": "openMRS.provider.display",
+          "fieldKey": "provider.person.display"
+        },
+        {
+          "displayName": "openMRS.location.id",
+          "fieldKey": "facility.id"
+        },
+        {
+          "displayName": "openMRS.location.display",
+          "fieldKey": "facility.display"
+        },
+        {
+          "displayName": "openMRS.patient.id",
+          "fieldKey": "patient.id"
+        },
+        {
+          "displayName": "openMRS.patient.display",
+          "fieldKey": "patient.person.display"
         }
       ]
     }

--- a/openmrs-19/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs-19/src/main/resources/webapp/messages/messages.properties
@@ -5,16 +5,32 @@ openMRS=OpenMRS
 openMRS.lookup.uuid=By UUID
 
 #OpenMRS model
+openMRS.encounter=Encounter
 openMRS.provider=Provider
 
 #Common field names
 openMRS.uuid=UUID
 
 #Field names for OpenMRS model
+#Encounter
+openMRS.encounter.date=Encounter date
+openMRS.encounter.display=Encounter display
+openMRS.encounter.id=Encounter UUID
+openMRS.encounter.type=Encounter type
+
+#Location
+openMRS.location.display=Location display
+openMRS.location.id=Location UUID
+
+#Patient
+openMRS.patient.display=Patient display
+openMRS.patient.id=Patient UUID
+
 #Person
 openMRS.person.display=Person display
 openMRS.person.id=Person UUID
 
 #Provider
-openMRS.provider.providerId=Provider UUID
+openMRS.provider.display=Provider display
+openMRS.provider.id=Provider UUID
 openMRS.provider.identifier=Provider identifier

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProviderTest.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProviderTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.openmrs19.domain.OpenMRSEncounter;
 import org.motechproject.openmrs19.domain.OpenMRSProvider;
+import org.motechproject.openmrs19.service.OpenMRSEncounterService;
 import org.motechproject.openmrs19.service.OpenMRSProviderService;
 import org.springframework.core.io.ResourceLoader;
 
@@ -25,6 +27,9 @@ import static org.motechproject.openmrs19.tasks.OpenMRSTasksConstants.UUID;
 public class OpenMRSTaskDataProviderTest {
 
     @Mock
+    private OpenMRSEncounterService encounterService;
+
+    @Mock
     private OpenMRSProviderService providerService;
 
     @Mock
@@ -34,7 +39,7 @@ public class OpenMRSTaskDataProviderTest {
 
     @Before
     public void setUp() {
-        taskDataProvider = new OpenMRSTaskDataProvider(resourceLoader, providerService);
+        taskDataProvider = new OpenMRSTaskDataProvider(resourceLoader, encounterService, providerService);
     }
 
     @Test
@@ -44,6 +49,57 @@ public class OpenMRSTaskDataProviderTest {
 
         assertNull(object);
         verifyZeroInteractions(providerService);
+    }
+
+    @Test
+    public void shouldReturnNullWhenWrongLookupNameForEncounter() {
+        String className = OpenMRSEncounter.class.getSimpleName();
+        Object object = taskDataProvider.lookup(className, "wrongLookupName", null);
+
+        assertNull(object);
+        verifyZeroInteractions(encounterService);
+    }
+
+    @Test
+    public void shouldReturnNullWhenEmptyLookupFieldsForLookupGetEncounterByUuid() {
+        String className = OpenMRSEncounter.class.getSimpleName();
+        Map<String, String> lookupFields = new HashMap<>();
+
+        when(encounterService.getEncounterByUuid(null)).thenReturn(null);
+        Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
+
+        assertNull(object);
+        verify(encounterService).getEncounterByUuid(null);
+    }
+
+    @Test
+    public void shouldReturnNullWhenEncounterNotFoundForLookupGetEncounterByUuid() {
+        String className = OpenMRSEncounter.class.getSimpleName();
+        Map<String, String> lookupFields = new HashMap<>();
+        lookupFields.put(UUID, "4");
+
+        when(encounterService.getEncounterByUuid("4")).thenReturn(null);
+        Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
+
+        assertNull(object);
+        verify(encounterService).getEncounterByUuid("4");
+    }
+
+    @Test
+    public void shouldReturnEncounterForLookupGetEncounterByUuid() {
+        String className = OpenMRSEncounter.class.getSimpleName();
+        Map<String, String> lookupFields = new HashMap<>();
+        lookupFields.put(UUID, "5");
+
+        OpenMRSEncounter openMRSEncounter = new OpenMRSEncounter();
+        openMRSEncounter.setEncounterType("encounterTypeTest");
+
+        when(encounterService.getEncounterByUuid("5")).thenReturn(openMRSEncounter);
+        Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
+
+        assertTrue(object instanceof OpenMRSEncounter);
+        assertEquals("encounterTypeTest", ((OpenMRSEncounter) object).getEncounterType());
+        verify(encounterService).getEncounterByUuid("5");
     }
 
     @Test
@@ -93,7 +149,7 @@ public class OpenMRSTaskDataProviderTest {
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
         assertTrue(object instanceof OpenMRSProvider);
-        assertEquals(((OpenMRSProvider) object).getIdentifier(), "testIdentifier");
+        assertEquals("testIdentifier", ((OpenMRSProvider) object).getIdentifier());
         verify(providerService).getProviderByUuid("5");
     }
 }

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProviderTest.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/OpenMRSTaskDataProviderTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -45,6 +44,7 @@ public class OpenMRSTaskDataProviderTest {
     @Test
     public void shouldReturnNullWhenClassIsNotSupported() {
         String className = "testClass";
+
         Object object = taskDataProvider.lookup(className, "lookupName", null);
 
         assertNull(object);
@@ -54,6 +54,7 @@ public class OpenMRSTaskDataProviderTest {
     @Test
     public void shouldReturnNullWhenWrongLookupNameForEncounter() {
         String className = OpenMRSEncounter.class.getSimpleName();
+
         Object object = taskDataProvider.lookup(className, "wrongLookupName", null);
 
         assertNull(object);
@@ -66,6 +67,7 @@ public class OpenMRSTaskDataProviderTest {
         Map<String, String> lookupFields = new HashMap<>();
 
         when(encounterService.getEncounterByUuid(null)).thenReturn(null);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
         assertNull(object);
@@ -79,6 +81,7 @@ public class OpenMRSTaskDataProviderTest {
         lookupFields.put(UUID, "4");
 
         when(encounterService.getEncounterByUuid("4")).thenReturn(null);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
         assertNull(object);
@@ -95,16 +98,17 @@ public class OpenMRSTaskDataProviderTest {
         openMRSEncounter.setEncounterType("encounterTypeTest");
 
         when(encounterService.getEncounterByUuid("5")).thenReturn(openMRSEncounter);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
-        assertTrue(object instanceof OpenMRSEncounter);
-        assertEquals("encounterTypeTest", ((OpenMRSEncounter) object).getEncounterType());
+        assertEquals(openMRSEncounter, object);
         verify(encounterService).getEncounterByUuid("5");
     }
 
     @Test
     public void shouldReturnNullWhenWrongLookupNameForProvider() {
         String className = OpenMRSProvider.class.getSimpleName();
+
         Object object = taskDataProvider.lookup(className, "wrongLookupName", null);
 
         assertNull(object);
@@ -117,6 +121,7 @@ public class OpenMRSTaskDataProviderTest {
         Map<String, String> lookupFields = new HashMap<>();
 
         when(providerService.getProviderByUuid(null)).thenReturn(null);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
         assertNull(object);
@@ -130,6 +135,7 @@ public class OpenMRSTaskDataProviderTest {
         lookupFields.put(UUID, "4");
 
         when(providerService.getProviderByUuid("4")).thenReturn(null);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
         assertNull(object);
@@ -146,10 +152,10 @@ public class OpenMRSTaskDataProviderTest {
         openMRSProvider.setIdentifier("testIdentifier");
 
         when(providerService.getProviderByUuid("5")).thenReturn(openMRSProvider);
+
         Object object = taskDataProvider.lookup(className, BY_UUID, lookupFields);
 
-        assertTrue(object instanceof OpenMRSProvider);
-        assertEquals("testIdentifier", ((OpenMRSProvider) object).getIdentifier());
+        assertEquals(openMRSProvider, object);
         verify(providerService).getProviderByUuid("5");
     }
 }


### PR DESCRIPTION
This PR adds next lookup to a task data source in OpenMRS module. I had to
adjust OpenMRS model in our Motech implementation. The following changes
had to be done:
- add display field to Encounter and OpenMRSEncounter
- add display field to Location and OpenMRSFacility

OpenMRSEncounter and OpenMRSFacility are Motech representation of Encounter
and Location model.

After this changes we have getEncounterByUuid lookup in OpenMRS task data source,
with the following fields :

Encounter UUID
Encounter display
Encounter date
Provider UUID
Provider display
Location UUID
Location display
Patient UUID
Patient display

In the spec for this issue there is information about OpenMRS Form, which is
related with Encounter. However, now we don't have Motech representation of
OpenMRS Form and that's why this field is not included in Encounter fields.
I will do it in another PR.

Lookups getPatientByUuid and getPatientByMotechId will be added in the separate
PR.
