### PR TITLE
MOTECH-2147 Extended CommcareFormService to allow uploading forms

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/client/CommCareAPIHttpClient.java
+++ b/commcare/src/main/java/org/motechproject/commcare/client/CommCareAPIHttpClient.java
@@ -14,13 +14,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.motechproject.commcare.config.AccountConfig;
-import org.motechproject.commcare.exception.CaseParserException;
 import org.motechproject.commcare.exception.CommcareAuthenticationException;
+import org.motechproject.commcare.exception.OpenRosaParserException;
 import org.motechproject.commcare.parser.OpenRosaResponseParser;
 import org.motechproject.commcare.request.FormListRequest;
+import org.motechproject.commcare.request.StockTransactionRequest;
 import org.motechproject.commcare.request.json.CaseRequest;
 import org.motechproject.commcare.request.json.Request;
-import org.motechproject.commcare.request.StockTransactionRequest;
 import org.motechproject.commcare.response.OpenRosaResponse;
 import org.motechproject.commcare.util.CommcareParamHelper;
 import org.slf4j.Logger;
@@ -51,17 +51,17 @@ public class CommCareAPIHttpClient {
     }
 
     /**
-     * Sends a POST request to the CommCare server. It will result in creating new case on the CommCare server based on
-     * the information given in the {@code caseXml}, which should be a valid case represented by an XML string.
+     * Sends a POST request to the CommCare server. It will result in creating new entry on the CommCare server based on
+     * the information given in the {@code xml}, which should be a valid case or form represented by an XML string.
      *
      * @param accountConfig  the CommCare account information
-     * @param caseXml  the case represented as an XML string
+     * @param xml  the submission represented as an XML string
      * @return the CommCare server response as an instance of the {@link OpenRosaResponse} class
-     * @throws CaseParserException if there were problems while parsing server response
+     * @throws OpenRosaParserException if there were problems while parsing server response
      */
-    public OpenRosaResponse caseUploadRequest(AccountConfig accountConfig, String caseXml)
-            throws CaseParserException {
-        return this.postRequest(accountConfig, commcareCaseUploadUrl(accountConfig), caseXml);
+    public OpenRosaResponse submissionRequest(AccountConfig accountConfig, String xml)
+            throws OpenRosaParserException {
+        return this.postRequest(accountConfig, commcareSubmissionUrl(accountConfig), xml);
     }
 
     /**
@@ -407,7 +407,7 @@ public class CommCareAPIHttpClient {
     }
 
     private OpenRosaResponse postRequest(AccountConfig accountConfig, String requestUrl, String body)
-            throws CaseParserException {
+            throws OpenRosaParserException {
 
         PostMethod postMethod = new PostMethod(requestUrl);
 
@@ -439,8 +439,7 @@ public class CommCareAPIHttpClient {
 
         OpenRosaResponseParser responseParser = new OpenRosaResponseParser();
 
-        OpenRosaResponse openRosaResponse = responseParser
-                .parseResponse(response);
+        OpenRosaResponse openRosaResponse = responseParser.parseResponse(response);
 
         if (openRosaResponse == null) {
             openRosaResponse = new OpenRosaResponse();
@@ -545,7 +544,7 @@ public class CommCareAPIHttpClient {
         return String.format("%s%s", commcareDataForwardingEndpointUrl(accountConfig), buildPaginationParams(pageSize, pageNumber));
     }
 
-    String commcareCaseUploadUrl(AccountConfig accountConfig) {
+    String commcareSubmissionUrl(AccountConfig accountConfig) {
         return String.format("%s/%s/receiver/", getCommcareBaseUrl(accountConfig.getBaseUrl()),
                 accountConfig.getDomain());
     }

--- a/commcare/src/main/java/org/motechproject/commcare/domain/FormXml.java
+++ b/commcare/src/main/java/org/motechproject/commcare/domain/FormXml.java
@@ -1,6 +1,8 @@
 package org.motechproject.commcare.domain;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -9,19 +11,23 @@ import java.util.Map;
  */
 public class FormXml {
 
-    private FormValueElement form;
+    private List<FormValueElement> formFields = new ArrayList<>();
     private Map<String, MetadataValue> metadata = new HashMap<>();
     private String name;
     private String version;
     private String uiversion;
     private String xmlns;
 
-    public FormValueElement getForm() {
-        return form;
+    public void addFormField(FormValueElement field) {
+        formFields.add(field);
     }
 
-    public void setForm(FormValueElement form) {
-        this.form = form;
+    public List<FormValueElement> getFormFields() {
+        return formFields;
+    }
+
+    public void setFormFields(List<FormValueElement> formFields) {
+        this.formFields = formFields;
     }
 
     public Map<String, MetadataValue> getMetadata() {

--- a/commcare/src/main/java/org/motechproject/commcare/exception/CaseParserException.java
+++ b/commcare/src/main/java/org/motechproject/commcare/exception/CaseParserException.java
@@ -1,8 +1,7 @@
 package org.motechproject.commcare.exception;
 
 /**
- * Thrown when there were problems while parsing case or {@link org.motechproject.commcare.response.OpenRosaResponse}
- * CommCare server response.
+ * Thrown when there were problems while parsing case.
  */
 public class CaseParserException extends Exception {
 

--- a/commcare/src/main/java/org/motechproject/commcare/exception/OpenRosaParserException.java
+++ b/commcare/src/main/java/org/motechproject/commcare/exception/OpenRosaParserException.java
@@ -1,0 +1,18 @@
+package org.motechproject.commcare.exception;
+
+/**
+ * Thrown when there were problems while parsing {@link org.motechproject.commcare.response.OpenRosaResponse}
+ * CommCare server response.
+ */
+public class OpenRosaParserException extends Exception {
+
+    private static final long serialVersionUID = 4646041644642523712L;
+
+    public OpenRosaParserException(String message) {
+        super(message);
+    }
+
+    public OpenRosaParserException(Exception ex, String message) {
+        super(message, ex);
+    }
+}

--- a/commcare/src/main/java/org/motechproject/commcare/parser/OpenRosaResponseParser.java
+++ b/commcare/src/main/java/org/motechproject/commcare/parser/OpenRosaResponseParser.java
@@ -1,7 +1,7 @@
 package org.motechproject.commcare.parser;
 
 import org.apache.xerces.parsers.DOMParser;
-import org.motechproject.commcare.exception.CaseParserException;
+import org.motechproject.commcare.exception.OpenRosaParserException;
 import org.motechproject.commcare.response.OpenRosaResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -21,10 +21,9 @@ public class OpenRosaResponseParser {
      *
      * @param response  the response to be parsed
      * @return the parsed response
-     * @throws CaseParserException if there where problems while parsing the response
+     * @throws OpenRosaParserException if there where problems while parsing the response
      */
-    public OpenRosaResponse parseResponse(String response)
-            throws CaseParserException {
+    public OpenRosaResponse parseResponse(String response) throws OpenRosaParserException {
         DOMParser parser = new DOMParser();
 
         OpenRosaResponse openRosaResponse = new OpenRosaResponse();
@@ -35,9 +34,9 @@ public class OpenRosaResponseParser {
         try {
             parser.parse(inputSource);
         } catch (IOException ex) {
-            throw new CaseParserException(ex, "Could not parse: IOException");
+            throw new OpenRosaParserException(ex, "Could not parse: IOException");
         } catch (SAXException ex) {
-            throw new CaseParserException(ex, "Could not parse: SAXException");
+            throw new OpenRosaParserException(ex, "Could not parse: SAXException");
         }
 
         Document document = parser.getDocument();

--- a/commcare/src/main/java/org/motechproject/commcare/request/converter/FormElementConverter.java
+++ b/commcare/src/main/java/org/motechproject/commcare/request/converter/FormElementConverter.java
@@ -33,6 +33,10 @@ public class FormElementConverter implements Converter {
     private static final String METADATA_XMLNS_VALUE = "http://openrosa.org/jr/xforms";
     private static final String METADATA_PREFIX = "n0:";
 
+    private static final String METADATA_APP_VERSION = "n1:appVersion";
+    private static final String METADATA_XMLNS = "xmlns:n1";
+    private static final String METADATA_XFORMS = "http://commcarehq.org/xforms";
+
 
     @Override
     public void marshal(Object o, HierarchicalStreamWriter writer, MarshallingContext marshallingContext) {
@@ -44,8 +48,10 @@ public class FormElementConverter implements Converter {
         addAttrIfNotEmpty(writer, XMLNS, formXml.getXmlns());
         addAttrIfNotEmpty(writer, XMLNS_JRM_KEY, XMLNS_JRM_VALUE);
 
-        if (formXml.getForm() != null) {
-            marshalFormValues(formXml.getForm(), writer);
+        if (formXml.getFormFields() != null && !formXml.getFormFields().isEmpty()) {
+            for (FormValueElement formField : formXml.getFormFields()) {
+                marshalFormValues(formField, writer);
+            }
         }
 
         if (!formXml.getMetadata().isEmpty()) {
@@ -74,6 +80,11 @@ public class FormElementConverter implements Converter {
                 writer.endNode();
             }
         }
+
+        writer.startNode(METADATA_APP_VERSION);
+        writer.addAttribute(METADATA_XMLNS, METADATA_XFORMS);
+        writer.setValue("2.0");
+        writer.endNode();
 
         writer.endNode();
     }

--- a/commcare/src/main/java/org/motechproject/commcare/service/CommcareFormService.java
+++ b/commcare/src/main/java/org/motechproject/commcare/service/CommcareFormService.java
@@ -2,7 +2,9 @@ package org.motechproject.commcare.service;
 
 import org.motechproject.commcare.domain.CommcareForm;
 import org.motechproject.commcare.domain.CommcareFormList;
+import org.motechproject.commcare.domain.FormXml;
 import org.motechproject.commcare.request.FormListRequest;
+import org.motechproject.commcare.response.OpenRosaResponse;
 
 /**
  * A service to perform queries against CommCareHQ form APIs.
@@ -54,4 +56,19 @@ public interface CommcareFormService {
      * Same as {@link #retrieveForm(String, String) retrieveFormJson} but uses default Commcare configuration.
      */
     String retrieveFormJson(String id);
+
+    /**
+     * Upload form xml wrapped in a minimal xform instance to CommCareHQ.
+     *
+     * @param formXml  An object representing the form information to be submitted as form xml
+     * @param configName  the name of the configuration used for connecting to CommcareHQ, null means default configuration
+     * @return  an informational object representing the status, nature and message of the response from CommCareHQ when
+     *          attempting to upload this instance of form xml.
+     */
+    OpenRosaResponse uploadForm(FormXml formXml, String configName);
+
+    /**
+     * Same as {@link #uploadForm(FormXml, String) uploadCase} but uses default Commcare configuration.
+     */
+    OpenRosaResponse uploadForm(FormXml formXml);
 }

--- a/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareFormServiceImpl.java
+++ b/commcare/src/main/java/org/motechproject/commcare/service/impl/CommcareFormServiceImpl.java
@@ -4,24 +4,33 @@ import org.motechproject.commcare.client.CommCareAPIHttpClient;
 import org.motechproject.commcare.config.AccountConfig;
 import org.motechproject.commcare.domain.CommcareForm;
 import org.motechproject.commcare.domain.CommcareFormList;
+import org.motechproject.commcare.domain.FormXml;
+import org.motechproject.commcare.exception.OpenRosaParserException;
+import org.motechproject.commcare.gateway.FormXmlConverter;
 import org.motechproject.commcare.parser.FormAdapter;
 import org.motechproject.commcare.request.FormListRequest;
+import org.motechproject.commcare.response.OpenRosaResponse;
 import org.motechproject.commcare.service.CommcareConfigService;
 import org.motechproject.commcare.service.CommcareFormService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CommcareFormServiceImpl implements CommcareFormService {
 
-    private CommCareAPIHttpClient commcareHttpClient;
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommcareFormServiceImpl.class);
 
+    private CommCareAPIHttpClient commcareHttpClient;
     private CommcareConfigService configService;
+    private FormXmlConverter converter;
 
     @Autowired
-    public CommcareFormServiceImpl(CommCareAPIHttpClient commcareHttpClient, CommcareConfigService configService) {
+    public CommcareFormServiceImpl(CommCareAPIHttpClient commcareHttpClient, CommcareConfigService configService, FormXmlConverter converter) {
         this.commcareHttpClient = commcareHttpClient;
         this.configService = configService;
+        this.converter = converter;
     }
 
     @Override
@@ -63,6 +72,27 @@ public class CommcareFormServiceImpl implements CommcareFormService {
     @Override
     public String retrieveFormJson(String id) {
         return retrieveFormJson(id, null);
+    }
+
+    @Override
+    public OpenRosaResponse uploadForm(FormXml formXml, String configName) {
+        String xml = converter.convertToFormXml(formXml);
+
+        LOGGER.debug("Sending the following Form XML to the Commcare server: {}", xml);
+        OpenRosaResponse response = null;
+        try {
+            response = commcareHttpClient.submissionRequest(configService.getByName(configName).getAccountConfig(), xml);
+            LOGGER.debug("Received the following response from the Commcare server. Status: {}, Message: {}", response.getStatus(), response.getMessageText());
+        } catch (OpenRosaParserException e) {
+            LOGGER.error("Failed to parse response from the CommCare server.", e);
+        }
+
+        return response;
+    }
+
+    @Override
+    public OpenRosaResponse uploadForm(FormXml formXml) {
+        return uploadForm(formXml, null);
     }
 
     private void setConfigNames(CommcareFormList formList, String configName) {

--- a/commcare/src/test/java/org/motechproject/commcare/client/CommCareAPIHttpClientTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/client/CommCareAPIHttpClientTest.java
@@ -78,7 +78,7 @@ public class CommCareAPIHttpClientTest {
 
     @Test
     public void shouldConstructCommcareCaseUploadUrl() {
-        assertThat(commCareAPIHttpClient.commcareCaseUploadUrl(accountConfig), equalTo(format("%s/%s/receiver/", baseUrl, domain)));
+        assertThat(commCareAPIHttpClient.commcareSubmissionUrl(accountConfig), equalTo(format("%s/%s/receiver/", baseUrl, domain)));
     }
 
     @Test

--- a/commcare/src/test/java/org/motechproject/commcare/gateway/FormXmlConverterTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/gateway/FormXmlConverterTest.java
@@ -57,7 +57,7 @@ public class FormXmlConverterTest {
         Map<String, MetadataValue> metadata = new HashMap<>();
         metadata.put("start_date", new MetadataValue(Arrays.asList("2016-01-01")));
 
-        form.setForm(motherElement);
+        form.setFormFields(Arrays.asList(motherElement));
         form.setMetadata(metadata);
 
         String formXml = formXmlConverter.convertToFormXml(form);
@@ -77,7 +77,7 @@ public class FormXmlConverterTest {
         motherElement.setElementName("");
         motherElement.addAttribute("name", "Jane");
 
-        form.setForm(motherElement);
+        form.setFormFields(Arrays.asList(motherElement));
 
         formXmlConverter.convertToFormXml(form);
     }

--- a/commcare/src/test/java/org/motechproject/commcare/service/impl/CommcareCaseServiceImplTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/service/impl/CommcareCaseServiceImplTest.java
@@ -52,7 +52,7 @@ public class CommcareCaseServiceImplTest {
 
         config = ConfigsUtils.prepareConfigOne();
 
-        when(configService.getDefault()).thenReturn(config);
+        when(configService.getByName(null)).thenReturn(config);
 
         caseService = new CommcareCaseServiceImpl(converter, commcareHttpClient, configService);
     }

--- a/commcare/src/test/resources/xml/sample_form_xml.xml
+++ b/commcare/src/test/resources/xml/sample_form_xml.xml
@@ -12,5 +12,6 @@
   </mother>
   <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
     <n0:start_date>2016-01-01</n0:start_date>
+    <n1:appVersion xmlns:n1="http://commcarehq.org/xforms">2.0</n1:appVersion>
   </n0:meta>
 </data>


### PR DESCRIPTION
The CommcareFormService has been extended and now allows to upload forms to the Commcare server via its submission API. The method name in CommcareHttpClient has been adjusted, since the endpoint it exposes is more generic and serves not only cases, but any submissions.
