### PR TITLE
MOTECH-2161: Adds getPatientByUuid and getPatientByMotechId lookups

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/OpenMrsInstance.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/OpenMrsInstance.java
@@ -1,5 +1,6 @@
 package org.motechproject.openmrs19;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.commons.api.MotechException;
 import org.motechproject.server.config.SettingsFacade;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,9 @@ import org.springframework.web.util.UriTemplate;
 import javax.annotation.PostConstruct;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Represents a single OpenMRS Web Application instance.
@@ -17,12 +21,14 @@ import java.net.URISyntaxException;
 @Component
 public class OpenMrsInstance {
 
+    private static final String OPENMRS_IDENTIFIER_TYPES_PROPERTY = "openmrs.identifierTypes";
     private static final String OPENMRS_MOTECH_ID_NAME_PROPERTY = "openmrs.motechIdName";
     private static final String OPENMRS_URL_PROPERTY = "openmrs.url";
     private static final String OPENMRS_WEB_SERVICE_PATH = "/ws/rest/v1";
 
     private String openmrsUrl;
     private String motechPatientIdentifierTypeName;
+    private List<String> patientIdentifierTypesNames;
 
     private SettingsFacade settingsFacade;
 
@@ -35,6 +41,7 @@ public class OpenMrsInstance {
     public void readSettings() {
         this.openmrsUrl = settingsFacade.getProperty(OPENMRS_URL_PROPERTY) + OPENMRS_WEB_SERVICE_PATH;
         this.motechPatientIdentifierTypeName = settingsFacade.getProperty(OPENMRS_MOTECH_ID_NAME_PROPERTY);
+        this.patientIdentifierTypesNames = parseIdentifierTypesProperty();
     }
 
     /**
@@ -69,5 +76,15 @@ public class OpenMrsInstance {
 
     public String getMotechPatientIdentifierTypeName() {
         return motechPatientIdentifierTypeName;
+    }
+
+    public List<String> getPatientIdentifierTypesNames() {
+        return patientIdentifierTypesNames;
+    }
+
+    private List<String> parseIdentifierTypesProperty() {
+        String property = settingsFacade.getProperty(OPENMRS_IDENTIFIER_TYPES_PROPERTY);
+
+        return StringUtils.isEmpty(property) ? new ArrayList<>() : Arrays.asList(property.split(","));
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/OpenMrsInstance.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/OpenMrsInstance.java
@@ -28,7 +28,7 @@ public class OpenMrsInstance {
 
     private String openmrsUrl;
     private String motechPatientIdentifierTypeName;
-    private List<String> patientIdentifierTypesNames;
+    private List<String> patientIdentifierTypeNames;
 
     private SettingsFacade settingsFacade;
 
@@ -41,7 +41,7 @@ public class OpenMrsInstance {
     public void readSettings() {
         this.openmrsUrl = settingsFacade.getProperty(OPENMRS_URL_PROPERTY) + OPENMRS_WEB_SERVICE_PATH;
         this.motechPatientIdentifierTypeName = settingsFacade.getProperty(OPENMRS_MOTECH_ID_NAME_PROPERTY);
-        this.patientIdentifierTypesNames = parseIdentifierTypesProperty();
+        this.patientIdentifierTypeNames = parseIdentifierTypesProperty();
     }
 
     /**
@@ -78,8 +78,8 @@ public class OpenMrsInstance {
         return motechPatientIdentifierTypeName;
     }
 
-    public List<String> getPatientIdentifierTypesNames() {
-        return patientIdentifierTypesNames;
+    public List<String> getPatientIdentifierTypeNames() {
+        return patientIdentifierTypeNames;
     }
 
     private List<String> parseIdentifierTypesProperty() {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
@@ -12,7 +12,7 @@ public class OpenMRSPatient {
     private OpenMRSFacility facility;
     private OpenMRSPerson person;
     private String motechId;
-    private Map<String, String> identifierTypesByValue;
+    private Map<String, String> identifiers;
 
     public OpenMRSPatient() {
         this(null);
@@ -40,35 +40,35 @@ public class OpenMRSPatient {
     }
 
     /**
-     * Creates a patient with the given {@code motechId} and {@code identifierTypesByValue} based on the given {@code person}
+     * Creates a patient with the given {@code motechId} and {@code identifiers} based on the given {@code person}
      * details and assigns it to the given {@code facility}.
      *
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
-     * @param identifierTypesByValue the identifiers of patient by value
+     * @param identifiers the supported identifiers of patient, key - name, value - identifier number
      */
-    public OpenMRSPatient(String motechId, OpenMRSPerson person, OpenMRSFacility facility, Map<String, String> identifierTypesByValue) {
-        this(null, motechId, person, facility, identifierTypesByValue);
+    public OpenMRSPatient(String motechId, OpenMRSPerson person, OpenMRSFacility facility, Map<String, String> identifiers) {
+        this(null, motechId, person, facility, identifiers);
     }
 
     /**
-     * Creates a patient with the given {@code motechId}, OpenMRS {@code patientId} and {@code identifierTypesByValue}
+     * Creates a patient with the given {@code motechId}, OpenMRS {@code patientId} and {@code identifiers}
      * based on the given {@code person} details and assigns it to the given {@code facility}.
      *
      * @param patientId  the OpenMRS ID of the patient
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
-     * @param identifierTypesByValue the identifiers of patient by value
+     * @param identifiers the supported identifiers of patient, key - name, value - identifier number
      */
     public OpenMRSPatient(String patientId, String motechId, OpenMRSPerson person, OpenMRSFacility facility,
-                          Map<String, String> identifierTypesByValue) {
+                          Map<String, String> identifiers) {
         this.patientId = patientId;
         this.motechId = motechId;
         this.person = person;
         this.facility = facility;
-        this.identifierTypesByValue = identifierTypesByValue;
+        this.identifiers = identifiers;
     }
 
     public String getPatientId() {
@@ -87,8 +87,8 @@ public class OpenMRSPatient {
         return motechId;
     }
 
-    public Map<String, String> getIdentifierTypesByValue() {
-        return identifierTypesByValue;
+    public Map<String, String> getIdentifiers() {
+        return identifiers;
     }
 
     @Override
@@ -105,7 +105,7 @@ public class OpenMRSPatient {
 
         return Objects.equals(facility, that.facility) && Objects.equals(patientId, that.patientId) &&
                 Objects.equals(motechId, that.motechId) && Objects.equals(person, that.person) &&
-                Objects.equals(identifierTypesByValue, that.identifierTypesByValue);
+                Objects.equals(identifiers, that.identifiers);
     }
 
     @Override
@@ -114,7 +114,7 @@ public class OpenMRSPatient {
         result = 31 * result + (facility != null ? facility.hashCode() : 0);
         result = 31 * result + (person != null ? person.hashCode() : 0);
         result = 31 * result + (motechId != null ? motechId.hashCode() : 0);
-        result = 31 * result + (identifierTypesByValue != null ? identifierTypesByValue.hashCode() : 0);
+        result = 31 * result + (identifiers != null ? identifiers.hashCode() : 0);
         return result;
     }
 
@@ -134,7 +134,7 @@ public class OpenMRSPatient {
         this.motechId = motechId;
     }
 
-    public void setIdentifierTypesByValue(Map<String, String> identifierTypesByValue) {
-        this.identifierTypesByValue = identifierTypesByValue;
+    public void setIdentifiers(Map<String, String> identifiers) {
+        this.identifiers = identifiers;
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
@@ -1,5 +1,6 @@
 package org.motechproject.openmrs19.domain;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -11,6 +12,7 @@ public class OpenMRSPatient {
     private OpenMRSFacility facility;
     private OpenMRSPerson person;
     private String motechId;
+    private Map<String, String> identifierTypesByValue;
 
     public OpenMRSPatient() {
         this(null);
@@ -22,7 +24,7 @@ public class OpenMRSPatient {
      * @param patientId  the OpenMRS ID of the patient
      */
     public OpenMRSPatient(String patientId) {
-        this(patientId, null, null, null);
+        this(patientId, null, null, null, null);
     }
 
     /**
@@ -34,23 +36,39 @@ public class OpenMRSPatient {
      * @param facility  the facility by which the patient is treated
      */
     public OpenMRSPatient(String motechId, OpenMRSPerson person, OpenMRSFacility facility) {
-        this(null, motechId, person, facility);
+        this(motechId, person, facility, null);
     }
 
     /**
-     * Creates a patient with the given {@code motechId} and OpenMRS {@code patientId} based on the given {@code person}
+     * Creates a patient with the given {@code motechId} and {@code identifierTypesByValue} based on the given {@code person}
      * details and assigns it to the given {@code facility}.
+     *
+     * @param motechId  the MOTECH ID of the patient
+     * @param person  the personal details about the patient
+     * @param facility  the facility by which the patient is treated
+     * @param identifierTypesByValue the identifiers of patient by value
+     */
+    public OpenMRSPatient(String motechId, OpenMRSPerson person, OpenMRSFacility facility, Map<String, String> identifierTypesByValue) {
+        this(null, motechId, person, facility, identifierTypesByValue);
+    }
+
+    /**
+     * Creates a patient with the given {@code motechId}, OpenMRS {@code patientId} and {@code identifierTypesByValue}
+     * based on the given {@code person} details and assigns it to the given {@code facility}.
      *
      * @param patientId  the OpenMRS ID of the patient
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
+     * @param identifierTypesByValue the identifiers of patient by value
      */
-    public OpenMRSPatient(String patientId, String motechId, OpenMRSPerson person, OpenMRSFacility facility) {
-        this.facility = facility;
-        this.person = person;
-        this.motechId = motechId;
+    public OpenMRSPatient(String patientId, String motechId, OpenMRSPerson person, OpenMRSFacility facility,
+                          Map<String, String> identifierTypesByValue) {
         this.patientId = patientId;
+        this.motechId = motechId;
+        this.person = person;
+        this.facility = facility;
+        this.identifierTypesByValue = identifierTypesByValue;
     }
 
     public String getPatientId() {
@@ -69,6 +87,10 @@ public class OpenMRSPatient {
         return motechId;
     }
 
+    public Map<String, String> getIdentifierTypesByValue() {
+        return identifierTypesByValue;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -82,7 +104,8 @@ public class OpenMRSPatient {
         OpenMRSPatient that = (OpenMRSPatient) o;
 
         return Objects.equals(facility, that.facility) && Objects.equals(patientId, that.patientId) &&
-                Objects.equals(motechId, that.motechId) && Objects.equals(person, that.person);
+                Objects.equals(motechId, that.motechId) && Objects.equals(person, that.person) &&
+                Objects.equals(identifierTypesByValue, that.identifierTypesByValue);
     }
 
     @Override
@@ -91,6 +114,7 @@ public class OpenMRSPatient {
         result = 31 * result + (facility != null ? facility.hashCode() : 0);
         result = 31 * result + (person != null ? person.hashCode() : 0);
         result = 31 * result + (motechId != null ? motechId.hashCode() : 0);
+        result = 31 * result + (identifierTypesByValue != null ? identifierTypesByValue.hashCode() : 0);
         return result;
     }
 
@@ -108,5 +132,9 @@ public class OpenMRSPatient {
 
     public void setMotechId(String motechId) {
         this.motechId = motechId;
+    }
+
+    public void setIdentifierTypesByValue(Map<String, String> identifierTypesByValue) {
+        this.identifierTypesByValue = identifierTypesByValue;
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
@@ -30,7 +30,7 @@ public class OpenMRSPerson {
     private Boolean birthDateEstimated;
     private Integer age;
     private String gender;
-    private boolean isDead;
+    private Boolean dead;
 
     private List<OpenMRSAttribute> attributes = new ArrayList<OpenMRSAttribute>();
     private DateTime deathDate;
@@ -103,8 +103,8 @@ public class OpenMRSPerson {
         this.lastName = lastName;
     }
 
-    public void setIsDead(Boolean isDead) {
-        this.isDead = isDead;
+    public void setDead(Boolean dead) {
+        this.dead = dead;
     }
 
     public String getFirstName() {
@@ -161,8 +161,9 @@ public class OpenMRSPerson {
         return birthDateEstimated;
     }
 
-    public Boolean isDead() {
-        return isDead;
+    // with getter isDead() task data source doesn't properly read this value
+    public Boolean getDead() {
+        return dead;
     }
 
     public Integer getAge() {
@@ -192,7 +193,7 @@ public class OpenMRSPerson {
         return equalNameData(other) && equalAgeAndBirthDates(other) && Objects.equals(id, other.id)
                 && Objects.equals(address, other.address) && Objects.equals(gender, other.gender)
                 && Objects.equals(attributes, other.attributes) && Objects.equals(deathDate, other.deathDate)
-                && isDead == other.isDead && Objects.equals(display, other.display);
+                && dead == other.dead && Objects.equals(display, other.display);
     }
 
     public boolean equalNameData(OpenMRSPerson other) {
@@ -219,7 +220,7 @@ public class OpenMRSPerson {
         hash = hash * 31 + ObjectUtils.hashCode(birthDateEstimated);
         hash = hash * 31 + ObjectUtils.hashCode(age);
         hash = hash * 31 + ObjectUtils.hashCode(gender);
-        hash = hash * 31 + Boolean.valueOf(isDead).hashCode();
+        hash = hash * 31 + Boolean.valueOf(dead).hashCode();
         hash = hash * 31 + ObjectUtils.hashCode(attributes);
         hash = hash * 31 + ObjectUtils.hashCode(deathDate);
         return hash;

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
@@ -161,7 +161,7 @@ public class OpenMRSPerson {
         return birthDateEstimated;
     }
 
-    // with getter isDead() task data source doesn't properly read this value
+    // TODO: MOTECH-2187: Task data source doesn't support boolean getters 'is..()'
     public Boolean getDead() {
         return dead;
     }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/helper/EventHelper.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/helper/EventHelper.java
@@ -67,7 +67,7 @@ public final class EventHelper {
         personParameters.put(EventKeys.PERSON_BIRTH_DATE_ESTIMATED, person.getBirthDateEstimated());
         personParameters.put(EventKeys.PERSON_AGE, person.getAge());
         personParameters.put(EventKeys.PERSON_GENDER, person.getGender());
-        personParameters.put(EventKeys.PERSON_DEAD, person.isDead());
+        personParameters.put(EventKeys.PERSON_DEAD, person.getDead());
         personParameters.put(EventKeys.PERSON_DEATH_DATE, person.getDeathDate());
         return personParameters;
     }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
@@ -39,10 +39,19 @@ public interface PatientResource {
     /**
      * Returns the UUID of the MOTECH patient identifier.
      *
-     * @return  the UUD of the MOTECH patient identifier
+     * @return  the UUID of the MOTECH patient identifier
      * @throws HttpException  when there were problems while fetching MOTECH patient identifier
      */
     String getMotechPatientIdentifierUuid() throws HttpException;
+
+    /**
+     * Returns the patient identifier name for the given uuid.
+     *
+     * @param uuid the UUID of the patient identifier
+     * @return the name of the patient identifier
+     * @throws HttpException when there were problems while fetching patient identifier
+     */
+    String getPatientIdentifierName(String uuid) throws HttpException;
 
     /**
      * Deletes the patient with the given UUID.

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
@@ -45,13 +45,14 @@ public interface PatientResource {
     String getMotechPatientIdentifierUuid() throws HttpException;
 
     /**
-     * Returns the patient identifier name for the given uuid.
+     * Returns the patient identifier type name for the given uuid only if the identifier type is supported
+     * by MOTECH.
      *
-     * @param uuid the UUID of the patient identifier
-     * @return the name of the patient identifier
+     * @param identifierTypeUuid the UUID of the patient identifier type
+     * @return the name of the patient identifier type
      * @throws HttpException when there were problems while fetching patient identifier
      */
-    String getPatientIdentifierName(String uuid) throws HttpException;
+    String getPatientIdentifierTypeNameByUuid(String identifierTypeUuid) throws HttpException;
 
     /**
      * Deletes the patient with the given UUID.

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
@@ -46,7 +46,7 @@ public interface PatientResource {
 
     /**
      * Returns the patient identifier type name for the given uuid only if the identifier type is supported
-     * by MOTECH.
+     * by MOTECH. This method is using cache while retrieving data from an OpenMRS server.
      *
      * @param identifierTypeUuid the UUID of the patient identifier type
      * @return the name of the patient identifier type

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/PatientResourceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/PatientResourceImpl.java
@@ -88,6 +88,7 @@ public class PatientResourceImpl implements PatientResource {
 
     @Override
     public String getPatientIdentifierTypeNameByUuid(String identifierTypeUuid) throws HttpException {
+        // Firstly, we try to retrieve a name from the cache
         String identifierTypeName = identifierTypeUuidByName.get(identifierTypeUuid);
 
         if (identifierTypeName == null) {
@@ -96,6 +97,7 @@ public class PatientResourceImpl implements PatientResource {
                 if (StringUtils.equals(identifierTypeUuid, type.getUuid())) {
                     if (isIdentifierTypeSupportedInMotech(type.getName())) {
                         identifierTypeName = type.getName();
+                        // After retrieving an identifierType from an OpenMRS server, the uuid and name are stored in cache
                         identifierTypeUuidByName.put(identifierTypeUuid, identifierTypeName);
                     }
 

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/PatientResourceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/PatientResourceImpl.java
@@ -22,6 +22,9 @@ import org.motechproject.openmrs19.util.JsonUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
 public class PatientResourceImpl implements PatientResource {
 
@@ -29,6 +32,7 @@ public class PatientResourceImpl implements PatientResource {
     private OpenMrsInstance openmrsInstance;
 
     private String motechIdTypeUuid;
+    private Map<String, String> identifierUuidByName = new HashMap<>();
 
     @Autowired
     public PatientResourceImpl(RestClient restClient, OpenMrsInstance instance) {
@@ -80,6 +84,27 @@ public class PatientResourceImpl implements PatientResource {
         }
 
         return motechIdTypeUuid;
+    }
+
+    @Override
+    public String getPatientIdentifierName(String uuid) throws HttpException {
+        String identifierName = identifierUuidByName.get(uuid);
+
+        if (identifierName == null) {
+            PatientIdentifierListResult result = getAllPatientIdentifierTypes();
+            for (IdentifierType type : result.getResults()) {
+                if (StringUtils.equals(uuid, type.getUuid())) {
+                    if (openmrsInstance.getPatientIdentifierTypesNames().contains(type.getName())) {
+                        identifierName = type.getName();
+                        identifierUuidByName.put(uuid, identifierName);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return identifierName;
     }
 
     @Override

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTasksConstants.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSTasksConstants.java
@@ -8,13 +8,16 @@ public final class OpenMRSTasksConstants {
     public static final String PACKAGE_ROOT = "org.motechproject.openmrs19.domain";
 
     // Lookup names
+    public static final String BY_MOTECH_ID = "openMRS.lookup.motechId";
     public static final String BY_UUID = "openMRS.lookup.uuid";
 
     // Lookup objects
     public static final String ENCOUNTER = "OpenMRSEncounter";
+    public static final String PATIENT = "OpenMRSPatient";
     public static final String PROVIDER = "OpenMRSProvider";
 
     // Field names
+    public static final String MOTECH_ID = "openMRS.motechId";
     public static final String UUID = "openMRS.uuid";
 
     private OpenMRSTasksConstants() {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
@@ -368,28 +368,30 @@ public final class ConverterUtils {
     }
 
     /**
-     * Creates an object of the MOTECH model patient based on the given OpenMRS model patient, facility and motechID.
+     * Creates an object of the MOTECH model patient based on the given OpenMRS model patient, facility, motechID and
+     * supportedIdentifierTypeList.
      *
      * @param patient  the patient(represented as OpenMRS model)
      * @param facility  the facility(represented as
      * @param motechId  the MOTECH ID of the patient
-     * @return
+     * @param supportedIdentifierTypeList  the supported patient identifier type list in MOTECH
+     * @return a Patient object converted to the MOTECH model representation of Patient
      */
     public static OpenMRSPatient toOpenMRSPatient(Patient patient, OpenMRSFacility facility, String motechId,
-                                                  List<Identifier> supportedIdentifierList) {
+                                                  List<Identifier> supportedIdentifierTypeList) {
         OpenMRSPatient openMRSPatient = new OpenMRSPatient(patient.getUuid());
 
-        Map<String, String> identifierTypesByValue = new HashMap<>();
+        Map<String, String> identifiers = new HashMap<>();
 
-        for (Identifier identifier :  supportedIdentifierList) {
+        for (Identifier identifier :  supportedIdentifierTypeList) {
             String identifierName = identifier.getIdentifierType().getName();
-            identifierTypesByValue.put(identifierName, identifier.getIdentifier());
+            identifiers.put(identifierName, identifier.getIdentifier());
         }
 
         openMRSPatient.setPerson(toOpenMRSPerson(patient.getPerson()));
         openMRSPatient.setFacility(facility);
         openMRSPatient.setMotechId(motechId);
-        openMRSPatient.setIdentifierTypesByValue(identifierTypesByValue);
+        openMRSPatient.setIdentifiers(identifiers);
 
         return openMRSPatient;
     }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
@@ -29,7 +29,9 @@ import org.motechproject.openmrs19.resource.model.Provider;
 import org.motechproject.openmrs19.resource.model.User;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility class for converting entities between the MOTECH and the OpenMRS models. The classes from the  MOTECH model
@@ -75,7 +77,9 @@ public final class ConverterUtils {
             converted.setDeathDate(new DateTime(person.getDeathDate()));
         }
 
-        converted.setIsDead(person.isDead());
+        converted.setDead(person.isDead());
+        converted.setAge(person.getAge());
+        converted.setBirthDateEstimated(person.isBirthdateEstimated());
 
         if (person.getAttributes() != null) {
             for (Attribute attr : person.getAttributes()) {
@@ -110,7 +114,7 @@ public final class ConverterUtils {
             converted.setDeathDate(person.getDeathDate().toDate());
         }
         converted.setBirthdateEstimated((Boolean) ObjectUtils.defaultIfNull(person.getBirthDateEstimated(), false));
-        converted.setDead(person.isDead());
+        converted.setDead(person.getDead());
         converted.setGender(person.getGender());
 
         if (includeNames) {
@@ -140,8 +144,8 @@ public final class ConverterUtils {
      * @return the location converted to the MOTECH model of the facility used by this module
      */
     public static OpenMRSFacility toOpenMRSFacility(Location location) {
-        return new OpenMRSFacility(location.getUuid(), location.getDisplay(), location.getName(),
-                location.getCountry(), location.getAddress6(), location.getCountyDistrict(), location.getStateProvince());
+        return new OpenMRSFacility(location.getUuid(), location.getDisplay(), location.getName(), location.getCountry(), location.getAddress6(),
+                location.getCountyDistrict(), location.getStateProvince());
     }
 
     /**
@@ -248,8 +252,8 @@ public final class ConverterUtils {
         person.setAge(personMrs.getAge());
         person.setBirthDateEstimated(personMrs.getBirthDateEstimated());
         person.setDateOfBirth(personMrs.getDateOfBirth());
-        if (personMrs.isDead() != null) {
-            person.setIsDead(personMrs.isDead());
+        if (personMrs.getDead() != null) {
+            person.setDead(personMrs.getDead());
         }
         person.setDeathDate(personMrs.getDeathDate());
         person.setGender(personMrs.getGender());
@@ -360,7 +364,7 @@ public final class ConverterUtils {
     }
 
     public static OpenMRSPatient toOpenMRSPatient(Patient patient) {
-        return toOpenMRSPatient(patient, null, null);
+        return toOpenMRSPatient(patient, null, null, null);
     }
 
     /**
@@ -371,13 +375,21 @@ public final class ConverterUtils {
      * @param motechId  the MOTECH ID of the patient
      * @return
      */
-    public static OpenMRSPatient toOpenMRSPatient(Patient patient, OpenMRSFacility facility, String motechId) {
-
+    public static OpenMRSPatient toOpenMRSPatient(Patient patient, OpenMRSFacility facility, String motechId,
+                                                  List<Identifier> supportedIdentifierList) {
         OpenMRSPatient openMRSPatient = new OpenMRSPatient(patient.getUuid());
+
+        Map<String, String> identifierTypesByValue = new HashMap<>();
+
+        for (Identifier identifier :  supportedIdentifierList) {
+            String identifierName = identifier.getIdentifierType().getName();
+            identifierTypesByValue.put(identifierName, identifier.getIdentifier());
+        }
 
         openMRSPatient.setPerson(toOpenMRSPerson(patient.getPerson()));
         openMRSPatient.setFacility(facility);
         openMRSPatient.setMotechId(motechId);
+        openMRSPatient.setIdentifierTypesByValue(identifierTypesByValue);
 
         return openMRSPatient;
     }

--- a/openmrs-19/src/main/resources/openmrs.properties
+++ b/openmrs-19/src/main/resources/openmrs.properties
@@ -2,4 +2,4 @@ openmrs.url=http://localhost:8080/openmrs
 openmrs.user=admin
 openmrs.password=Admin123
 openmrs.motechIdName=MOTECH Id
-openmrs.identifierTypes=CommCare CaseID
+openmrs.identifierTypes=

--- a/openmrs-19/src/main/resources/openmrs.properties
+++ b/openmrs-19/src/main/resources/openmrs.properties
@@ -2,3 +2,4 @@ openmrs.url=http://localhost:8080/openmrs
 openmrs.user=admin
 openmrs.password=Admin123
 openmrs.motechIdName=MOTECH Id
+openmrs.identifierTypes=CommCare CaseID

--- a/openmrs-19/src/main/resources/task-data-provider.json
+++ b/openmrs-19/src/main/resources/task-data-provider.json
@@ -2,36 +2,6 @@
   "name": "openMRS",
   "objects": [
     {
-      "displayName": "openMRS.provider",
-      "type": "OpenMRSProvider",
-      "lookupFields": [
-        {
-          "displayName": "openMRS.lookup.uuid",
-          "fields": [
-            "openMRS.uuid"
-          ]
-        }
-      ],
-      "fields": [
-        {
-          "displayName": "openMRS.provider.id",
-          "fieldKey": "providerId"
-        },
-        {
-          "displayName": "openMRS.provider.identifier",
-          "fieldKey": "identifier"
-        },
-        {
-          "displayName": "openMRS.person.id",
-          "fieldKey": "person.id"
-        },
-        {
-          "displayName": "openMRS.person.display",
-          "fieldKey": "person.display"
-        }
-      ]
-    },
-    {
       "displayName": "openMRS.encounter",
       "type": "OpenMRSEncounter",
       "lookupFields": [
@@ -83,6 +53,110 @@
         {
           "displayName": "openMRS.patient.display",
           "fieldKey": "patient.person.display"
+        }
+      ]
+    },
+    {
+      "displayName": "openMRS.patient",
+      "type": "OpenMRSPatient",
+      "lookupFields": [
+        {
+          "displayName": "openMRS.lookup.motechId",
+          "fields": [
+            "openMRS.motechId"
+          ]
+        },
+        {
+          "displayName": "openMRS.lookup.uuid",
+          "fields": [
+            "openMRS.uuid"
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "displayName": "openMRS.patient.id",
+          "fieldKey": "patientId"
+        },
+        {
+          "displayName": "openMRS.patient.identifiers",
+          "fieldKey": "identifierTypesByValue",
+          "type": "MAP"
+        },
+        {
+          "displayName": "openMRS.motechId",
+          "fieldKey": "motechId"
+        },
+        {
+          "displayName": "openMRS.person.id",
+          "fieldKey": "person.id"
+        },
+        {
+          "displayName": "openMRS.person.display",
+          "fieldKey": "person.display"
+        },
+        {
+          "displayName": "openMRS.person.address",
+          "fieldKey": "person.address"
+        },
+        {
+          "displayName": "openMRS.person.age",
+          "fieldKey": "person.age",
+          "type": "INTEGER"
+        },
+        {
+          "displayName": "openMRS.person.birthDateEstimated",
+          "fieldKey": "person.birthDateEstimated",
+          "type": "BOOLEAN"
+        },
+        {
+          "displayName": "openMRS.person.dateOfBirth",
+          "fieldKey": "person.dateOfBirth",
+          "type": "DATE"
+        },
+        {
+          "displayName": "openMRS.person.deathDate",
+          "fieldKey": "person.deathDate",
+          "type": "DATE"
+        },
+        {
+          "displayName": "openMRS.person.gender",
+          "fieldKey": "person.gender"
+        },
+        {
+          "displayName": "openMRS.person.dead",
+          "fieldKey": "person.dead",
+          "type": "BOOLEAN"
+        }
+      ]
+    },
+    {
+      "displayName": "openMRS.provider",
+      "type": "OpenMRSProvider",
+      "lookupFields": [
+        {
+          "displayName": "openMRS.lookup.uuid",
+          "fields": [
+            "openMRS.uuid"
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "displayName": "openMRS.provider.id",
+          "fieldKey": "providerId"
+        },
+        {
+          "displayName": "openMRS.provider.identifier",
+          "fieldKey": "identifier"
+        },
+        {
+          "displayName": "openMRS.person.id",
+          "fieldKey": "person.id"
+        },
+        {
+          "displayName": "openMRS.person.display",
+          "fieldKey": "person.display"
         }
       ]
     }

--- a/openmrs-19/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs-19/src/main/resources/webapp/messages/messages.properties
@@ -2,13 +2,16 @@
 openMRS=OpenMRS
 
 #Lookup names
+openMRS.lookup.motechId=By MotechId
 openMRS.lookup.uuid=By UUID
 
 #OpenMRS model
 openMRS.encounter=Encounter
+openMRS.patient=Patient
 openMRS.provider=Provider
 
 #Common field names
+openMRS.motechId=MotechId
 openMRS.uuid=UUID
 
 #Field names for OpenMRS model
@@ -25,9 +28,17 @@ openMRS.location.id=Location UUID
 #Patient
 openMRS.patient.display=Patient display
 openMRS.patient.id=Patient UUID
+openMRS.patient.identifiers=Patient identifiers
 
 #Person
+openMRS.person.address=Person address
+openMRS.person.age=Person age
+openMRS.person.birthDateEstimated=Person birthDateEstimated flag
+openMRS.person.dateOfBirth=Person date of birth
+openMRS.person.dead=Person dead flag
+openMRS.person.deathDate=Person date of death
 openMRS.person.display=Person display
+openMRS.person.gender=Person gender
 openMRS.person.id=Person UUID
 
 #Provider

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPatientServiceIT.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPatientServiceIT.java
@@ -155,7 +155,7 @@ public class MRSPatientServiceIT extends BasePaxIT {
 
         patientAdapter.deceasePatient(patient.getMotechId(), causeOfDeath, new Date(), null);
         OpenMRSPatient deceased = patientAdapter.getPatientByMotechId(patient.getMotechId());
-        assertTrue(deceased.getPerson().isDead());
+        assertTrue(deceased.getPerson().getDead());
     }
 
     @Test

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
@@ -146,7 +146,7 @@ public class MRSPersonServiceIT extends BasePaxIT {
         person.setBirthDateEstimated(false);
         person.setGender("M");
         person.setAge(25);
-        person.setIsDead(false);
+        person.setDead(false);
         person.setMiddleName("John");
 
         OpenMRSAttribute attr = new OpenMRSAttribute("Birthplace", "Motech");


### PR DESCRIPTION
This commit adds two lookups to a task data source in OpenMRS module : getPatientByUuid and getPatientByMotechId.

The object fields for Patient are :
- Patient UUID
- Patient identifiers
- Motech ID
- Person UUID
- Person Display
- Person address
- Person age
- Person birthDateEstimated flag
- Person date of birth
- Person date of death
- Person gender
- Person dead flag

I had to make some changes in OpenMRS model. Previously we supported only Motech ID as an identifier for Patient. Now we can get others identifiers from Patient. To define identifiers, which we want to retrieve from Patient, we should add a property to openmrs.properties. For example :
- openmrs.identifierTypes=CommCare CaseID.

Then, we will get the value for mentioned identifiers. 

Additionally I had to change getter name for dead field in OpenMRSPerson. A task data source doesn't properly read value if the getter for boolean has 'isDead' form.

Moreover I changed validation for OpenMRSPatient before save. Now OpenMRS doesn't require a location for Patient identifier.  

Also I added few tests.
