### PR TITLE
MOTECH-2162: Adds a task action createEncounter to OpenMRS module.

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSEncounter.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSEncounter.java
@@ -3,6 +3,7 @@ package org.motechproject.openmrs19.domain;
 import org.joda.time.DateTime;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -225,5 +226,33 @@ public class OpenMRSEncounter {
 
     public void setObservations(Set<? extends OpenMRSObservation> observations) {
         this.observations = observations;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, display, provider, creator, facility, date, observations, patient, encounterType);
+    }
+
+    @Override //NO CHECKSTYLE Cyclomatic Complexity
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        OpenMRSEncounter other = (OpenMRSEncounter) obj;
+
+        return Objects.equals(this.id, other.id) &&
+                Objects.equals(this.display, other.display) &&
+                Objects.equals(this.provider, other.provider) &&
+                Objects.equals(this.creator, other.creator) &&
+                Objects.equals(this.facility, other.facility) &&
+                Objects.equals(this.date, other.date) &&
+                Objects.equals(this.observations, other.observations) &&
+                Objects.equals(this.patient, other.patient) &&
+                Objects.equals(this.encounterType, other.encounterType);
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSProvider.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSProvider.java
@@ -1,5 +1,7 @@
 package org.motechproject.openmrs19.domain;
 
+import java.util.Objects;
+
 /**
  * Represents a single provider. Provider is a clinician responsible for providing care to a patient. It's part of the
  * MOTECH model.
@@ -48,5 +50,27 @@ public class OpenMRSProvider {
 
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(providerId, person, identifier);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        OpenMRSProvider other = (OpenMRSProvider) obj;
+
+        return Objects.equals(this.providerId, other.providerId) &&
+                Objects.equals(this.person, other.person) &&
+                Objects.equals(this.identifier, other.identifier);
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSEncounterServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSEncounterServiceImpl.java
@@ -5,13 +5,13 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventRelay;
-import org.motechproject.openmrs19.domain.OpenMRSEncounterType;
-import org.motechproject.openmrs19.service.EventKeys;
 import org.motechproject.openmrs19.domain.OpenMRSEncounter;
+import org.motechproject.openmrs19.domain.OpenMRSEncounterType;
 import org.motechproject.openmrs19.domain.OpenMRSObservation;
 import org.motechproject.openmrs19.domain.OpenMRSPatient;
 import org.motechproject.openmrs19.domain.OpenMRSPerson;
 import org.motechproject.openmrs19.domain.OpenMRSProvider;
+import org.motechproject.openmrs19.exception.HttpException;
 import org.motechproject.openmrs19.helper.EventHelper;
 import org.motechproject.openmrs19.resource.EncounterResource;
 import org.motechproject.openmrs19.resource.model.Concept;
@@ -23,7 +23,7 @@ import org.motechproject.openmrs19.resource.model.Observation;
 import org.motechproject.openmrs19.resource.model.Observation.ObservationValue;
 import org.motechproject.openmrs19.resource.model.Patient;
 import org.motechproject.openmrs19.resource.model.Person;
-import org.motechproject.openmrs19.exception.HttpException;
+import org.motechproject.openmrs19.service.EventKeys;
 import org.motechproject.openmrs19.service.OpenMRSEncounterService;
 import org.motechproject.openmrs19.service.OpenMRSPatientService;
 import org.motechproject.openmrs19.util.ConverterUtils;
@@ -97,6 +97,7 @@ public class OpenMRSEncounterServiceImpl implements OpenMRSEncounterService {
         Validate.notNull(encounter, "Encounter cannot be null");
         Validate.notNull(encounter.getPatient(), "Patient cannot be null");
         Validate.notEmpty(encounter.getPatient().getPatientId(), "Patient must have an id");
+        Validate.notNull(encounter.getProvider(), "Provider cannot be null");
         Validate.notNull(encounter.getDate(), "Encounter Date cannot be null");
         Validate.notEmpty(encounter.getEncounterType(), "Encounter type cannot be empty");
     }
@@ -109,9 +110,11 @@ public class OpenMRSEncounterServiceImpl implements OpenMRSEncounterService {
         encounterType.setName(encounter.getEncounterType());
         converted.setEncounterType(encounterType);
 
-        Location location = new Location();
-        location.setUuid(encounter.getFacility().getFacilityId());
-        converted.setLocation(location);
+        if (encounter.getFacility() != null) {
+            Location location = new Location();
+            location.setUuid(encounter.getFacility().getFacilityId());
+            converted.setLocation(location);
+        }
 
         Patient patient = new Patient();
         patient.setUuid(encounter.getPatient().getPatientId());
@@ -153,13 +156,15 @@ public class OpenMRSEncounterServiceImpl implements OpenMRSEncounterService {
 
     private Set<? extends OpenMRSObservation> resolveConceptUuidForConceptNames(Set<? extends OpenMRSObservation> originalObservations) {
         Set<OpenMRSObservation> updatedObs = new HashSet<>();
-        for (OpenMRSObservation observation : originalObservations) {
-            String conceptUuid = conceptAdapter.resolveConceptUuidFromConceptName(observation.getConceptName());
-            if (CollectionUtils.isNotEmpty(observation.getDependentObservations())) {
-                resolveConceptUuidForConceptNames(observation.getDependentObservations());
+        if (originalObservations != null) {
+            for (OpenMRSObservation observation : originalObservations) {
+                String conceptUuid = conceptAdapter.resolveConceptUuidFromConceptName(observation.getConceptName());
+                if (CollectionUtils.isNotEmpty(observation.getDependentObservations())) {
+                    resolveConceptUuidForConceptNames(observation.getDependentObservations());
+                }
+                updatedObs.add(new OpenMRSObservation(observation.getObservationId(), observation.getDate().toDate(), conceptUuid, observation
+                        .getValue()));
             }
-            updatedObs.add(new OpenMRSObservation(observation.getObservationId(), observation.getDate().toDate(), conceptUuid, observation
-                    .getValue()));
         }
 
         return updatedObs;

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSActionProxyService.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/OpenMRSActionProxyService.java
@@ -1,0 +1,21 @@
+package org.motechproject.openmrs19.tasks;
+
+import org.joda.time.DateTime;
+
+/**
+ * Proxy registered with the task channel, exposing the OpenMRS service as task actions.
+ */
+public interface OpenMRSActionProxyService {
+
+    /**
+     * Creates an encounter with the given {@code encounterDate}, {@code encounterType}, {@code locationName},
+     * {@code patientUuid} and {@code providerUuid}. The locationName is the only not required field.
+     *
+     * @param encounterDate the date of encounter
+     * @param encounterType the type of encounter
+     * @param locationName the name of location
+     * @param patientUuid the patient uuid
+     * @param providerUuid the provider uuid
+     */
+    void createEncounter(DateTime encounterDate, String encounterType, String locationName, String patientUuid, String providerUuid);
+}

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceImpl.java
@@ -1,0 +1,85 @@
+package org.motechproject.openmrs19.tasks.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.motechproject.openmrs19.domain.OpenMRSEncounter;
+import org.motechproject.openmrs19.domain.OpenMRSFacility;
+import org.motechproject.openmrs19.domain.OpenMRSPatient;
+import org.motechproject.openmrs19.domain.OpenMRSProvider;
+import org.motechproject.openmrs19.service.OpenMRSEncounterService;
+import org.motechproject.openmrs19.service.OpenMRSFacilityService;
+import org.motechproject.openmrs19.service.OpenMRSPatientService;
+import org.motechproject.openmrs19.service.OpenMRSProviderService;
+import org.motechproject.openmrs19.tasks.OpenMRSActionProxyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("openMRSActionProxyService")
+public class OpenMRSActionProxyServiceImpl implements OpenMRSActionProxyService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenMRSActionProxyServiceImpl.class);
+
+    private OpenMRSEncounterService encounterService;
+    private OpenMRSFacilityService facilityService;
+    private OpenMRSPatientService patientService;
+    private OpenMRSProviderService providerService;
+
+    @Override
+    public void createEncounter(DateTime encounterDate, String encounterType, String locationName, String patientUuid, String providerUuid) {
+        OpenMRSFacility facility = getFacilityByName(locationName);
+        OpenMRSPatient patient = patientService.getPatientByUuid(patientUuid);
+        OpenMRSProvider provider = providerService.getProviderByUuid(providerUuid);
+
+        OpenMRSEncounter encounter = new OpenMRSEncounter.OpenMRSEncounterBuilder()
+                .withDate(encounterDate.toDate())
+                .withEncounterType(encounterType)
+                .withFacility(facility)
+                .withPatient(patient)
+                .withProvider(provider)
+                .build();
+
+        encounterService.createEncounter(encounter);
+    }
+
+    private OpenMRSFacility getFacilityByName(String locationName) {
+        OpenMRSFacility facility = null;
+
+        if (StringUtils.isNotEmpty(locationName)) {
+            List<? extends OpenMRSFacility> facilities = facilityService.getFacilities(locationName);
+            if (facilities.isEmpty()) {
+                LOGGER.warn("There is no location with name {}", locationName);
+            } else {
+                if (facilities.size() > 1) {
+                    LOGGER.warn("There is more than one location with name {}.", locationName);
+                }
+                facility = facilities.get(0);
+            }
+        }
+
+        return facility;
+    }
+
+    @Autowired
+    public void setEncounterService(OpenMRSEncounterService encounterService) {
+        this.encounterService = encounterService;
+    }
+
+    @Autowired
+    public void setFacilityService(OpenMRSFacilityService facilityService) {
+        this.facilityService = facilityService;
+    }
+
+    @Autowired
+    public void setPatientService(OpenMRSPatientService patientService) {
+        this.patientService = patientService;
+    }
+
+    @Autowired
+    public void setProviderService(OpenMRSProviderService providerService) {
+        this.providerService = providerService;
+    }
+}

--- a/openmrs-19/src/main/resources/META-INF/spring/blueprint.xml
+++ b/openmrs-19/src/main/resources/META-INF/spring/blueprint.xml
@@ -18,6 +18,7 @@
     <osgi:service ref="userService" interface="org.motechproject.openmrs19.service.OpenMRSUserService"/>
     <osgi:service ref="providerService" interface="org.motechproject.openmrs19.service.OpenMRSProviderService"/>
     <osgi:service ref="openMRSTaskDataProvider" interface="org.motechproject.commons.api.DataProvider"/>
+    <osgi:service ref="openMRSActionProxyService" interface="org.motechproject.openmrs19.tasks.OpenMRSActionProxyService"/>
 
     <osgi:reference id="eventListenerRegistryServiceOsgi" interface="org.motechproject.event.listener.EventListenerRegistryService"/>
 

--- a/openmrs-19/src/main/resources/task-channel.json
+++ b/openmrs-19/src/main/resources/task-channel.json
@@ -19,7 +19,8 @@
         },
         {
           "key": "locationName",
-          "displayName": "openMRS.location.name"
+          "displayName": "openMRS.location.name",
+          "required" : false
         },
         {
           "key": "patientUuid",

--- a/openmrs-19/src/main/resources/task-channel.json
+++ b/openmrs-19/src/main/resources/task-channel.json
@@ -1,0 +1,37 @@
+{
+  "displayName": "openMRS",
+  "actionTaskEvents": [
+    {
+      "displayName": "openMRS.createEncounter",
+      "serviceInterface": "org.motechproject.openmrs19.tasks.OpenMRSActionProxyService",
+      "serviceMethod": "createEncounter",
+      "actionParameters": [
+        {
+          "key": "encounterDate",
+          "displayName": "openMRS.encounter.date",
+          "type": "DATE",
+          "required" : true
+        },
+        {
+          "key": "encounterType",
+          "displayName": "openMRS.encounter.type",
+          "required" : true
+        },
+        {
+          "key": "locationName",
+          "displayName": "openMRS.location.name"
+        },
+        {
+          "key": "patientUuid",
+          "displayName": "openMRS.patient.id",
+          "required" : true
+        },
+        {
+          "key": "providerUuid",
+          "displayName": "openMRS.provider.id",
+          "required" : true
+        }
+      ]
+    }
+  ]
+}

--- a/openmrs-19/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs-19/src/main/resources/webapp/messages/messages.properties
@@ -5,6 +5,9 @@ openMRS=OpenMRS
 openMRS.lookup.motechId=By MotechId
 openMRS.lookup.uuid=By UUID
 
+#Actions
+openMRS.createEncounter=Create Encounter
+
 #OpenMRS model
 openMRS.encounter=Encounter
 openMRS.patient=Patient
@@ -24,6 +27,7 @@ openMRS.encounter.type=Encounter type
 #Location
 openMRS.location.display=Location display
 openMRS.location.id=Location UUID
+openMRS.location.name=Location name
 
 #Patient
 openMRS.patient.display=Patient display

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceTest.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceTest.java
@@ -8,11 +8,15 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.openmrs19.domain.OpenMRSEncounter;
 import org.motechproject.openmrs19.domain.OpenMRSFacility;
 import org.motechproject.openmrs19.domain.OpenMRSPatient;
 import org.motechproject.openmrs19.domain.OpenMRSPerson;
+import org.motechproject.openmrs19.domain.OpenMRSProvider;
+import org.motechproject.openmrs19.service.OpenMRSEncounterService;
 import org.motechproject.openmrs19.service.OpenMRSFacilityService;
 import org.motechproject.openmrs19.service.OpenMRSPatientService;
+import org.motechproject.openmrs19.service.OpenMRSProviderService;
 import org.motechproject.openmrs19.tasks.OpenMRSActionProxyService;
 
 import java.util.Collections;
@@ -27,16 +31,56 @@ import static org.mockito.Mockito.verify;
 public class OpenMRSActionProxyServiceTest {
 
     @Mock
+    private OpenMRSEncounterService encounterService;
+
+    @Mock
     private OpenMRSFacilityService facilityService;
 
     @Mock
     private OpenMRSPatientService patientService;
+
+    @Mock
+    private OpenMRSProviderService providerService;
+
+    @Captor
+    private ArgumentCaptor<OpenMRSEncounter> encounterCaptor;
 
     @Captor
     private ArgumentCaptor<OpenMRSPatient> patientCaptor;
 
     @InjectMocks
     private OpenMRSActionProxyService openMRSActionProxyService = new OpenMRSActionProxyServiceImpl();
+
+    @Test
+    public void shouldCreateEncounterWithGivenParameters() {
+        OpenMRSFacility facility = new OpenMRSFacility(null);
+        facility.setName("testLocation");
+
+        OpenMRSPatient patient = new OpenMRSPatient();
+        patient.setPatientId("10");
+
+        OpenMRSProvider provider = new OpenMRSProvider();
+        provider.setProviderId("20");
+
+        OpenMRSEncounter encounter = new OpenMRSEncounter.OpenMRSEncounterBuilder()
+                .withDate(new DateTime("2000-08-16T07:22:05Z").toDate())
+                .withEncounterType("testEncounterType")
+                .withFacility(facility)
+                .withPatient(patient)
+                .withProvider(provider)
+                .build();
+
+        doReturn(Collections.singletonList(facility)).when(facilityService).getFacilities(facility.getName());
+        doReturn(patient).when(patientService).getPatientByUuid(patient.getPatientId());
+        doReturn(provider).when(providerService).getProviderByUuid(provider.getProviderId());
+
+        openMRSActionProxyService.createEncounter(encounter.getDate(), encounter.getEncounterType(), facility.getName(),
+                patient.getPatientId(), provider.getProviderId());
+
+        verify(encounterService).createEncounter(encounterCaptor.capture());
+
+        assertEquals(encounter, encounterCaptor.getValue());
+    }
 
     @Test
     public void shouldCreatePatientWithGivenParameters() {


### PR DESCRIPTION
This PR adds a task action createEncounter to OpenMRS module.
This action has the following fields :
- Date encounterDate
- String encounterType
- String locationName (not required)
- String patientUuid
- String providerUuid

I added a new validation condition before saving encounter. The provider cannot be null. I checked it and this is required by an OpenMRS server. 
