### PR TITLE
MOTECH-2162: Adds possibility to store patient identifiers

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
@@ -89,7 +89,11 @@ public class OpenMRSPatient {
     }
 
     public Map<String, String> getIdentifiers() {
-        return identifiers == null ? new HashMap<>() : identifiers;
+        if (identifiers == null) {
+            identifiers = new HashMap<>();
+        }
+
+        return identifiers;
     }
 
     @Override

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPatient.java
@@ -1,5 +1,6 @@
 package org.motechproject.openmrs19.domain;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -46,7 +47,7 @@ public class OpenMRSPatient {
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
-     * @param identifiers the supported identifiers of patient, key - name, value - identifier number
+     * @param identifiers the supported identifiers of patient, key - identifier type name, value - identifier number
      */
     public OpenMRSPatient(String motechId, OpenMRSPerson person, OpenMRSFacility facility, Map<String, String> identifiers) {
         this(null, motechId, person, facility, identifiers);
@@ -60,7 +61,7 @@ public class OpenMRSPatient {
      * @param motechId  the MOTECH ID of the patient
      * @param person  the personal details about the patient
      * @param facility  the facility by which the patient is treated
-     * @param identifiers the supported identifiers of patient, key - name, value - identifier number
+     * @param identifiers the supported identifiers of patient, key - identifier type name, value - identifier number
      */
     public OpenMRSPatient(String patientId, String motechId, OpenMRSPerson person, OpenMRSFacility facility,
                           Map<String, String> identifiers) {
@@ -88,7 +89,7 @@ public class OpenMRSPatient {
     }
 
     public Map<String, String> getIdentifiers() {
-        return identifiers;
+        return identifiers == null ? new HashMap<>() : identifiers;
     }
 
     @Override

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/PatientResource.java
@@ -55,6 +55,16 @@ public interface PatientResource {
     String getPatientIdentifierTypeNameByUuid(String identifierTypeUuid) throws HttpException;
 
     /**
+     * Returns the UUID of the patient identifier type for the given name only if the identifier type is supported
+     * by MOTECH. This method is using cache while retrieving data from an OpenMRS server.
+     *
+     * @param identifierTypeName the name of the patient identifier type
+     * @return the UUID of the patient identifier type
+     * @throws HttpException when there were problems while fetching patient identifier
+     */
+    String getPatientIdentifierTypeUuidByName(String identifierTypeName) throws HttpException;
+
+    /**
      * Deletes the patient with the given UUID.
      *
      * @param uuid  the UUID of the patient

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSPatientServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSPatientServiceImpl.java
@@ -29,7 +29,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service("patientService")
 public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
@@ -126,7 +128,9 @@ public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
             person = patient.getPerson();
         }
 
-        Patient converted = ConverterUtils.toPatient(openMRSPatient, person, getMotechPatientIdentifierTypeUuid());
+        Map<String, String> parsedPatientIdentifiers = parsePatientIdentifiers(openMRSPatient.getIdentifiers());
+
+        Patient converted = ConverterUtils.toPatient(openMRSPatient, person, getMotechPatientIdentifierTypeUuid(), parsedPatientIdentifiers);
 
         try {
             OpenMRSPatient savedPatient = ConverterUtils.toOpenMRSPatient(patientResource.createPatient(converted));
@@ -144,6 +148,7 @@ public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
         Validate.notNull(patient, "Patient cannot be null");
         Validate.isTrue(StringUtils.isNotEmpty(patient.getMotechId()), "You must provide a motech id to save a patient");
         Validate.notNull(patient.getPerson(), "Person cannot be null when saving a patient");
+        Validate.notNull(patient.getFacility(), "Facility cannot be null when saving a patient");
     }
 
     @Override
@@ -284,18 +289,45 @@ public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
                 try {
                     String identifierTypeName = patientResource.getPatientIdentifierTypeNameByUuid(identifierTypeUuid);
                     if (identifierTypeName == null) {
-                        LOGGER.warn("The identifier with UUID {} is not supported", identifierTypeUuid);
+                        LOGGER.warn("The identifier type with UUID {} is not supported", identifierTypeUuid);
                     } else {
                         identifier.getIdentifierType().setName(identifierTypeName);
                         supportedIdentifierTypeList.add(identifier);
                     }
                 } catch (HttpException e) {
-                    LOGGER.error("There was an exception retrieving the identifier with UUID {}", identifierTypeUuid);
+                    LOGGER.error("There was an exception retrieving the identifier type with UUID {}", identifierTypeUuid);
                     return null;
                 }
             }
         }
 
         return supportedIdentifierTypeList;
+    }
+
+    /**
+     * Parses patient identifiers. This method checks if the given identifier type name is supported by MOTECH
+     * and swaps identifier type name for identifier type uuid.
+     *
+     * @param identifiers the identifiers of patient, key - identifier type name, value - identifier number
+     * @return parsed patient identifiers, key - identifier type uuid, value - identifier number
+     */
+    private Map<String, String> parsePatientIdentifiers(Map<String, String> identifiers) {
+        Map<String, String> parsedIdentifiers = new HashMap<>();
+
+        for (String identifierTypeName : identifiers.keySet()) {
+            try {
+                String identifierTypeUuid = patientResource.getPatientIdentifierTypeUuidByName(identifierTypeName);
+                if (identifierTypeUuid == null) {
+                    LOGGER.warn("The identifier type with name {} is not supported", identifierTypeName);
+                } else {
+                    parsedIdentifiers.put(identifierTypeUuid, identifiers.get(identifierTypeName));
+                }
+            } catch (HttpException e) {
+                LOGGER.error("There was an exception retrieving the identifier type with name {}", identifierTypeName);
+                return null;
+            }
+        }
+
+        return parsedIdentifiers;
     }
 }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/util/ConverterUtils.java
@@ -114,7 +114,7 @@ public final class ConverterUtils {
             converted.setDeathDate(person.getDeathDate().toDate());
         }
         converted.setBirthdateEstimated((Boolean) ObjectUtils.defaultIfNull(person.getBirthDateEstimated(), false));
-        converted.setDead(person.getDead());
+        converted.setDead((Boolean) ObjectUtils.defaultIfNull(person.getDead(), false));
         converted.setGender(person.getGender());
 
         if (includeNames) {
@@ -231,6 +231,7 @@ public final class ConverterUtils {
         openMRSPatient.setFacility(openMRSFacility);
         openMRSPatient.setPerson(openMRSPerson);
         openMRSPatient.setMotechId(patient.getMotechId());
+        openMRSPatient.setIdentifiers(patient.getIdentifiers());
 
         return openMRSPatient;
     }
@@ -372,7 +373,7 @@ public final class ConverterUtils {
      * supportedIdentifierTypeList.
      *
      * @param patient  the patient(represented as OpenMRS model)
-     * @param facility  the facility(represented as
+     * @param facility  the facility(represented as MOTECH model)
      * @param motechId  the MOTECH ID of the patient
      * @param supportedIdentifierTypeList  the supported patient identifier type list in MOTECH
      * @return a Patient object converted to the MOTECH model representation of Patient
@@ -383,9 +384,11 @@ public final class ConverterUtils {
 
         Map<String, String> identifiers = new HashMap<>();
 
-        for (Identifier identifier :  supportedIdentifierTypeList) {
-            String identifierName = identifier.getIdentifierType().getName();
-            identifiers.put(identifierName, identifier.getIdentifier());
+        if (supportedIdentifierTypeList != null) {
+            for (Identifier identifier : supportedIdentifierTypeList) {
+                String identifierName = identifier.getIdentifierType().getName();
+                identifiers.put(identifierName, identifier.getIdentifier());
+            }
         }
 
         openMRSPatient.setPerson(toOpenMRSPerson(patient.getPerson()));
@@ -396,7 +399,18 @@ public final class ConverterUtils {
         return openMRSPatient;
     }
 
-    public static Patient toPatient(OpenMRSPatient patient, OpenMRSPerson savedPerson, String motechPatientIdentifierTypeUuid) {
+
+    /**
+     * Converts the given patient, represented as the MOTECH model, to the model used by the OpenMRS server.
+     *
+     * @param patient  the MOTECH model of patient
+     * @param savedPerson  the savedPerson connected with the given patient
+     * @param motechPatientIdentifierTypeUuid  the MOTECH identifier type uuid
+     * @param patientIdentifiers the patient identifiers to be stored, key - identifier type uuid, value - identifier number
+     * @return an OpenMRS representation of patient object
+     */
+    public static Patient toPatient(OpenMRSPatient patient, OpenMRSPerson savedPerson, String motechPatientIdentifierTypeUuid,
+                                    Map<String, String> patientIdentifiers) {
 
         Patient converted = new Patient();
         Person person = new Person();
@@ -409,16 +423,21 @@ public final class ConverterUtils {
             location.setUuid(patient.getFacility().getFacilityId());
         }
 
-        IdentifierType type = new IdentifierType();
-        type.setUuid(motechPatientIdentifierTypeUuid);
-
-        Identifier identifier = new Identifier();
-        identifier.setIdentifier(patient.getMotechId());
-        identifier.setLocation(location);
-        identifier.setIdentifierType(type);
-
         List<Identifier> identifiers = new ArrayList<>();
-        identifiers.add(identifier);
+        identifiers.add(createMotechPatientIdentifier(patient.getMotechId(), motechPatientIdentifierTypeUuid, location));
+
+        for (String identifierTypeUuid : patientIdentifiers.keySet()) {
+            IdentifierType type = new IdentifierType();
+            type.setUuid(identifierTypeUuid);
+
+            Identifier identifier = new Identifier();
+            identifier.setIdentifier(patientIdentifiers.get(identifierTypeUuid));
+            identifier.setLocation(location);
+            identifier.setIdentifierType(type);
+
+            identifiers.add(identifier);
+        }
+
         converted.setIdentifiers(identifiers);
 
         return converted;
@@ -485,5 +504,17 @@ public final class ConverterUtils {
         conceptName.setConceptNameType(openMRSConceptName.getConceptNameType());
 
         return conceptName;
+    }
+
+    private static Identifier createMotechPatientIdentifier(String motechId, String motechPatientIdentifierTypeUuid, Location location) {
+        IdentifierType type = new IdentifierType();
+        type.setUuid(motechPatientIdentifierTypeUuid);
+
+        Identifier identifier = new Identifier();
+        identifier.setIdentifier(motechId);
+        identifier.setLocation(location);
+        identifier.setIdentifierType(type);
+
+        return identifier;
     }
 }


### PR DESCRIPTION
This PR adds possibility to store patient identifiers. After defining custom
identifier type name in openmrs.properties, a user can store identifier
using map in OpenMRSPatient (key - identifier type name, value - identifier
number).

I restored the validation condition while saving OpenMRSPatient. Every patient
identifier must have location. By default an OpenMRS server creates location
named "Unknown Location", so a user can use this location while creating
OpenMRSPatient.
