### PR TITLE
MOTECH-2084: Renamed org.motechproject.tasks.ex package

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/tasks/CommcareTasksNotifier.java
+++ b/commcare/src/main/java/org/motechproject/commcare/tasks/CommcareTasksNotifier.java
@@ -4,7 +4,7 @@ import org.motechproject.commcare.CommcareDataProvider;
 import org.motechproject.commcare.service.CommcareConfigService;
 import org.motechproject.commcare.service.CommcareSchemaService;
 import org.motechproject.commcare.tasks.builder.ChannelRequestBuilder;
-import org.motechproject.tasks.ex.ValidationException;
+import org.motechproject.tasks.exception.ValidationException;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;

--- a/sms/src/main/java/org/motechproject/sms/tasks/SmsTasksNotifier.java
+++ b/sms/src/main/java/org/motechproject/sms/tasks/SmsTasksNotifier.java
@@ -5,7 +5,7 @@ package org.motechproject.sms.tasks;
 import org.motechproject.sms.configs.Config;
 import org.motechproject.sms.service.ConfigService;
 import org.motechproject.sms.tasks.builder.ChannelRequestBuilder;
-import org.motechproject.tasks.ex.ValidationException;
+import org.motechproject.tasks.exception.ValidationException;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;


### PR DESCRIPTION
Changed name of the org.motechproject.tasks.ex package to org.motechproject.tasks.exception.

Requires https://github.com/motech/motech/pull/366
