### PR TITLE
MOTECH-2157 Added ability to access repeat data in CC form

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/parser/FullFormParser.java
+++ b/commcare/src/main/java/org/motechproject/commcare/parser/FullFormParser.java
@@ -108,10 +108,10 @@ public class FullFormParser {
 
                 if (StringUtils.isNotBlank(value)) {
                     childElement.setValue(value);
-                } else {
-                    addAttributes(childElement, child.getAttributes());
-                    addSubElements(childElement, child.getChildNodes());
                 }
+
+                addAttributes(childElement, child.getAttributes());
+                addSubElements(childElement, child.getChildNodes());
 
                 element.addFormValueElement(childElement.getElementName(), childElement);
             }

--- a/commcare/src/test/java/org/motechproject/commcare/service/impl/parser/CommcareEventParsersTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/service/impl/parser/CommcareEventParsersTest.java
@@ -46,6 +46,7 @@ public class CommcareEventParsersTest {
     private CommcareCaseEventParser caseEventParser;
 
     private MotechEvent formsEvent;
+    private MotechEvent formsEventWithRepeatData;
     private MotechEvent caseEvent;
 
     private Config config;
@@ -71,15 +72,17 @@ public class CommcareEventParsersTest {
 
         ArgumentCaptor<MotechEvent> captor = ArgumentCaptor.forClass(MotechEvent.class);
         formsController.receiveForm(ResponseXML.getFormXML(), request);
+        formsController.receiveForm(ResponseXML.getFormXMLWithRepeatData(), request);
 
         request.setContent(ResponseXML.getCaseXML().getBytes());
         casesController.receiveCase(request, config.getName());
 
         // Capture MotechEvents
-        verify(eventRelay, times(2)).sendEventMessage(captor.capture());
+        verify(eventRelay, times(3)).sendEventMessage(captor.capture());
         // Assign them to test fields for later use in tests
         formsEvent = captor.getAllValues().get(0);
-        caseEvent = captor.getAllValues().get(1);
+        formsEventWithRepeatData = captor.getAllValues().get(1);
+        caseEvent = captor.getAllValues().get(2);
     }
 
     @Test
@@ -107,6 +110,28 @@ public class CommcareEventParsersTest {
         assertEquals(ATTR1_VALUE, parsedParameters.get("/data/pregnant"));
         assertEquals(ATTR2_VALUE, parsedParameters.get("/data/dob"));
         assertEquals("test", parsedParameters.get("/data/meta/username"));
+    }
+
+    @Test
+    public void shouldParseFormsEventWithRepeatDataProperly() {
+        String eventSubject = formsEventWithRepeatData.getSubject();
+        Map<String, Object> eventParameters = formsEventWithRepeatData.getParameters();
+
+        Map<String, Object> parsedParameters = formsEventParser.parseEventParameters(eventSubject, eventParameters);
+
+        assertTrue(parsedParameters.containsKey("/data/clinic"));
+        assertTrue(parsedParameters.containsKey("/data/diseases/disease_3893289/medication_55665"));
+        assertTrue(parsedParameters.containsKey("/data/diseases/disease_3893289/medication_55666"));
+        assertTrue(parsedParameters.containsKey("/data/diseases/disease_3893289/medication_55667"));
+        assertTrue(parsedParameters.containsKey("/data/diseases/disease_9539823/medication_55666"));
+        assertTrue(parsedParameters.containsKey("/data/diseases/disease_9539823/medication_55668"));
+
+        assertEquals("Clinic1", parsedParameters.get("/data/clinic"));
+        assertEquals("Med1", parsedParameters.get("/data/diseases/disease_3893289/medication_55665"));
+        assertEquals("Med2", parsedParameters.get("/data/diseases/disease_3893289/medication_55666"));
+        assertEquals("Med3", parsedParameters.get("/data/diseases/disease_3893289/medication_55667"));
+        assertEquals("Med2", parsedParameters.get("/data/diseases/disease_9539823/medication_55666"));
+        assertEquals("Med4", parsedParameters.get("/data/diseases/disease_9539823/medication_55668"));
     }
 
     @Test

--- a/commcare/src/test/java/org/motechproject/commcare/util/ResponseXML.java
+++ b/commcare/src/test/java/org/motechproject/commcare/util/ResponseXML.java
@@ -50,6 +50,36 @@ public final class ResponseXML {
                 "</data>";
     }
 
+    public static String getFormXMLWithRepeatData() {
+        return "<data uiVersion=\"1\"\n" +
+                "      version=\"41\"\n" +
+                "      name=\"Diseases\"\n" +
+                "      xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\"\n" +
+                "      xmlns=\"" + DummyCommcareSchema.XMLNS1 + "\">\n" +
+                "  <clinic>Clinic1</clinic>\n" +
+                "  <diseases>\n" +
+                "    <disease id=\"3893289\" index=\"0\">\n" +
+                "      <medication id=\"55665\">Med1</medication>\n" +
+                "      <medication id=\"55666\">Med2</medication>\n" +
+                "      <medication id=\"55667\">Med3</medication>\n" +
+                "    </disease>\n" +
+                "    <disease id=\"9539823\" index=\"1\">\n" +
+                "      <medication id=\"55666\">Med2</medication>\n" +
+                "      <medication id=\"55668\">Med4</medication>\n" +
+                "    </disease>\n" +
+                "  </diseases>\n" +
+                "  <n2:meta xmlns:n2=\"http://openrosa.org/jr/xforms\">\n" +
+                "  <n2:deviceID>cloudcare</n2:deviceID>\n" +
+                "  <n2:timeStart>2012-10-23T17:15:18.324-04</n2:timeStart>\n" +
+                "  <n2:timeEnd>2012-10-23T17:15:21.966-04</n2:timeEnd>\n" +
+                "  <n2:username>test</n2:username>\n" +
+                "  <n2:userID>9ad3659b9c0f8c5d141d2d06857874df</n2:userID>\n" +
+                "  <n2:instanceID>c24a85f9-703d-434c-b087-5759f3fa9937</n2:instanceID>\n" +
+                "  <n3:appVersion xmlns:n3=\"http://commcarehq.org/xforms\">2.0</n3:appVersion>\n" +
+                "  </n2:meta>\n" +
+                "</data>";
+    }
+
     public static String getCaseXML() {
         return "<case case_id=\"e6552468-e7ac-4bd1-86bd-4fd72094ccc2\" date_modified=\"2014-09-24T13:14:50Z\"" +
                 " user_id=\"2a34e758b7ed8a686e7fe8de29c3078c\" xmlns=\"http://commcarehq.org/case/transaction/v2\">" +


### PR DESCRIPTION
In case the CommCare form received by the Commcare module
contains repeat data, they will now be available in task
triggers, by specifing the id of the repeated element after
the underscore character in the trigger key, for example:
/data/repeatedElement_123
