### PR TITLE
MOTECH-2201 Fixed create case task action [0.28.X]

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/domain/UpdateTask.java
+++ b/commcare/src/main/java/org/motechproject/commcare/domain/UpdateTask.java
@@ -11,7 +11,7 @@ public class UpdateTask {
     private String caseName;
     private String dateOpened;
     private String ownerId;
-    private Map<String, String> fieldValues;
+    private Map<String, Object> fieldValues;
 
     public String getCaseType() {
         return this.caseType;
@@ -45,11 +45,11 @@ public class UpdateTask {
         this.ownerId = ownerId;
     }
 
-    public Map<String, String> getFieldValues() {
+    public Map<String, Object> getFieldValues() {
         return this.fieldValues;
     }
 
-    public void setFieldValues(Map<String, String> fieldValues) {
+    public void setFieldValues(Map<String, Object> fieldValues) {
         this.fieldValues = fieldValues;
     }
 }

--- a/commcare/src/main/java/org/motechproject/commcare/events/CaseEventHandler.java
+++ b/commcare/src/main/java/org/motechproject/commcare/events/CaseEventHandler.java
@@ -43,7 +43,7 @@ public class CaseEventHandler {
 
         // <update> tag
         UpdateTask updateTask = new UpdateTask();
-        updateTask.setFieldValues((Map<String, String>) parameters.get(EventDataKeys.FIELD_VALUES));
+        updateTask.setFieldValues((Map<String, Object>) parameters.get(EventDataKeys.FIELD_VALUES));
 
         caseTask.setCreateTask(createTask);
         caseTask.setUpdateTask(updateTask);
@@ -63,7 +63,7 @@ public class CaseEventHandler {
         // <update> tag
         UpdateTask updateTask = new UpdateTask();
         updateTask.setOwnerId((String) parameters.get(EventDataKeys.OWNER_ID));
-        updateTask.setFieldValues((Map<String, String>) parameters.get(EventDataKeys.FIELD_VALUES));
+        updateTask.setFieldValues((Map<String, Object>) parameters.get(EventDataKeys.FIELD_VALUES));
 
         // optional <close> tag
         if (parameters.get(EventDataKeys.CLOSE_CASE) != null && (Boolean) parameters.get(EventDataKeys.CLOSE_CASE)) {

--- a/commcare/src/main/java/org/motechproject/commcare/request/converter/UpdateElementConverter.java
+++ b/commcare/src/main/java/org/motechproject/commcare/request/converter/UpdateElementConverter.java
@@ -48,12 +48,12 @@ public class UpdateElementConverter implements Converter {
             writer.endNode();
         }
 
-        Map<String, String> fieldValues = element.getFieldValues();
+        Map<String, Object> fieldValues = element.getFieldValues();
 
         if (fieldValues != null) {
-            for (Map.Entry<String, String> entry : fieldValues.entrySet()) {
+            for (Map.Entry<String, Object> entry : fieldValues.entrySet()) {
                 writer.startNode(entry.getKey());
-                writer.setValue(entry.getValue());
+                writer.setValue(entry.getValue().toString());
                 writer.endNode();
             }
         }

--- a/commcare/src/test/java/org/motechproject/commcare/gateway/CaseTaskXmlConverterTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/gateway/CaseTaskXmlConverterTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.commcare.gateway;
 
 import junit.framework.Assert;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -173,11 +175,13 @@ public class CaseTaskXmlConverterTest {
 
         UpdateTask updateTask = new UpdateTask();
 
-        Map<String, String> fieldValues = new HashMap<String, String>();
+        Map<String, Object> fieldValues = new HashMap<>();
 
         fieldValues.put("KEY1", "VALUE1");
         fieldValues.put("KEY2", "VALUE2");
         fieldValues.put("KEY3", "VALUE3");
+        fieldValues.put("KEY4", 4);
+        fieldValues.put("KEY5", new DateTime(1456250266046L, DateTimeZone.UTC));
 
         updateTask.setCaseName("CASE_NAME");
         updateTask.setCaseType("CASE_TYPE");
@@ -201,6 +205,8 @@ public class CaseTaskXmlConverterTest {
         Assert.assertTrue(xml.contains("<KEY2>VALUE2</KEY2>"));
         Assert.assertTrue(xml.contains("<KEY1>VALUE1</KEY1>"));
         Assert.assertTrue(xml.contains("<KEY3>VALUE3</KEY3>"));
+        Assert.assertTrue(xml.contains("<KEY4>4</KEY4>"));
+        Assert.assertTrue(xml.contains("<KEY5>2016-02-23T17:57:46.046Z</KEY5>"));
     }
 
     @Test

--- a/commcare/src/test/java/org/motechproject/commcare/service/impl/CommcareCaseServiceImplTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/service/impl/CommcareCaseServiceImplTest.java
@@ -98,8 +98,7 @@ public class CommcareCaseServiceImplTest {
     }
 
     @Test
-    public void testAllCaseServerDateModified()
-    {
+    public void testAllCaseServerDateModified() {
         when(commcareHttpClient.casesRequest(any(AccountConfig.class), any(CaseRequest.class))).thenReturn(casesResponse());
 
         List<CaseInfo> cases = caseService.getCases(50, 1);


### PR DESCRIPTION
Create case event handler was using Strings to handle field values.
I've adjusted this to use generic Object and invoke toString() on the values while parsing to XML.
