### PR TITLE
MOTECH-2162: Fixes bug in createPatient action

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/OpenMRSPerson.java
@@ -223,7 +223,8 @@ public class OpenMRSPerson {
                 && Objects.equals(address, other.address) && Objects.equals(gender, other.gender)
                 && Objects.equals(attributes, other.attributes) && Objects.equals(deathDate, other.deathDate)
                 && dead == other.dead && Objects.equals(display, other.display)
-                && Objects.equals(dateCreated, other.dateCreated) && Objects.equals(dateChanged, other.dateChanged);
+                && Objects.equals(dateCreated, other.dateCreated) && Objects.equals(dateChanged, other.dateChanged)
+                && Objects.equals(causeOfDeath, other.causeOfDeath);
     }
 
     public boolean equalNameData(OpenMRSPerson other) {
@@ -255,6 +256,7 @@ public class OpenMRSPerson {
         hash = hash * 31 + ObjectUtils.hashCode(deathDate);
         hash = hash * 31 + ObjectUtils.hashCode(dateCreated);
         hash = hash * 31 + ObjectUtils.hashCode(dateChanged);
+        hash = hash * 31 + ObjectUtils.hashCode(causeOfDeath);
         return hash;
     }
 

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSPatientServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/service/impl/OpenMRSPatientServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service("patientService")
 public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
@@ -149,6 +150,10 @@ public class OpenMRSPatientServiceImpl implements OpenMRSPatientService {
         Validate.isTrue(StringUtils.isNotEmpty(patient.getMotechId()), "You must provide a motech id to save a patient");
         Validate.notNull(patient.getPerson(), "Person cannot be null when saving a patient");
         Validate.notNull(patient.getFacility(), "Facility cannot be null when saving a patient");
+        if (Objects.equals(patient.getPerson().getDead(), true)) {
+            Validate.notNull(patient.getPerson().getCauseOfDeath(), "Cause of death cannot be null when dead flag is set to true");
+        }
+
     }
 
     @Override

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceImpl.java
@@ -57,7 +57,7 @@ public class OpenMRSActionProxyServiceImpl implements OpenMRSActionProxyService 
     public void createPatient(String firstName, String middleName, String lastName, String address, DateTime dateOfBirth,
                               Boolean birthDateEstimated, String gender, Boolean dead, String causeOfDeathUUID, String motechId,
                               String locationName, Map<String, String> identifiers) {
-        OpenMRSConcept causeOfDeath = conceptService.getConceptByUuid(causeOfDeathUUID);
+        OpenMRSConcept causeOfDeath = StringUtils.isNotEmpty(causeOfDeathUUID) ? conceptService.getConceptByUuid(causeOfDeathUUID) : null;
 
         OpenMRSPerson person = new OpenMRSPerson();
         person.setFirstName(firstName);

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceTest.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/tasks/impl/OpenMRSActionProxyServiceTest.java
@@ -8,6 +8,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.openmrs19.domain.OpenMRSConcept;
+import org.motechproject.openmrs19.domain.OpenMRSConceptName;
 import org.motechproject.openmrs19.domain.OpenMRSEncounter;
 import org.motechproject.openmrs19.domain.OpenMRSFacility;
 import org.motechproject.openmrs19.domain.OpenMRSPatient;
@@ -89,6 +91,10 @@ public class OpenMRSActionProxyServiceTest {
     @Test
     public void shouldCreatePatientWithGivenParameters() {
         OpenMRSPerson person = createTestPerson();
+        OpenMRSConcept causeOfDeath = createTestConcept();
+
+        person.setDead(true);
+        person.setCauseOfDeath(causeOfDeath);
 
         OpenMRSFacility facility = new OpenMRSFacility();
         facility.setName("testLocation");
@@ -98,11 +104,12 @@ public class OpenMRSActionProxyServiceTest {
 
         OpenMRSPatient patient = new OpenMRSPatient("500", person, facility, identifiers);
 
+        doReturn(causeOfDeath).when(conceptService).getConceptByUuid(causeOfDeath.getUuid());
         doReturn(Collections.singletonList(facility)).when(facilityService).getFacilities(facility.getName());
 
         openMRSActionProxyService.createPatient(person.getFirstName(), person.getMiddleName(), person.getLastName(),
                 person.getAddress(), person.getDateOfBirth(), person.getBirthDateEstimated(), person.getGender(),
-                person.getDead(), "", patient.getMotechId(), facility.getName(), identifiers);
+                person.getDead(), causeOfDeath.getUuid(), patient.getMotechId(), facility.getName(), identifiers);
 
         verify(patientService).createPatient(patientCaptor.capture());
 
@@ -168,5 +175,17 @@ public class OpenMRSActionProxyServiceTest {
         person.setDead(false);
 
         return person;
+    }
+
+    private OpenMRSConcept createTestConcept() {
+        OpenMRSConcept concept = new OpenMRSConcept();
+        OpenMRSConceptName conceptName = new OpenMRSConceptName("testConcept");
+
+        concept.setNames(Collections.singletonList(conceptName));
+        concept.setDataType("TEXT");
+        concept.setConceptClass("Test");
+        concept.setUuid("100");
+
+        return concept;
     }
 }


### PR DESCRIPTION
There was a problem with cause of death while creating patient. I made the following changes:
- when you set dead flag to true while creating patient, a cause of death has to be provided (new condition in validatePatientBeforeSave),
- when you set dead flag to false while creating patient, a cause of death field can be empty,
- the unit test testing createPatient action now includes a cause of death when dead flag is set to true. 
