### PR TITLE
MOTECH-2162: Changes type of gender field in createPatient action [0.28.X]

### DIFF
--- a/openmrs-19/src/main/resources/task-channel.json
+++ b/openmrs-19/src/main/resources/task-channel.json
@@ -74,6 +74,11 @@
         {
           "key": "gender",
           "displayName": "openMRS.person.gender",
+          "type" : "SELECT",
+          "options" : [
+            "M",
+            "F"
+          ],
           "required" : true
         },
         {


### PR DESCRIPTION
The OpenMRS server accepts 'F' and 'M' (representating 'Female' and 'Male)
values in gender field in Person. This PR changes type in task action.
Now user can select value instead of providing raw string.
