### PR TITLE
MOTECH-2202: fix failing IT test

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Person.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/model/Person.java
@@ -469,7 +469,7 @@ public class Person {
                     .append(address4).append(",").append(address5).append(",")
                     .append(address6).append(",").append(startDate).append(",")
                     .append(endDate).append(",").append(latitude).append(",")
-                    .append(longitude).append(",")
+                    .append(longitude)
                     .toString();
         }
 

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
@@ -70,11 +70,6 @@ public class MRSPersonServiceIT extends BasePaxIT {
         assertFalse(mrsListener.updated);
     }
 
-    /*
-        We are able to convert fields from openMRS to single string field only for now
-        that is why we are checking assertTrue with contains function for changed address
-        rather than assertEquals for string field
-     */
     @Test
     public void shouldUpdatePerson() throws OpenMRSException, InterruptedException {
 
@@ -103,6 +98,9 @@ public class MRSPersonServiceIT extends BasePaxIT {
         assertEquals(newFirstName, updated.getFirstName());
         assertEquals(newMiddleName, updated.getMiddleName());
         assertEquals(newLastName, updated.getLastName());
+        // So far OpenMRS module stores only one field of person's address, which is 'address1'.
+        // However while retrieving person from OpenMRS server all person's address fields are put
+        // into one string. That's why it is checked if address field contains address1 value.
         assertTrue(updated.getAddress().contains(newAddress));
         assertEquals(newGender, updated.getGender());
 

--- a/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
+++ b/openmrs-19/src/test/java/org/motechproject/openmrs19/it/MRSPersonServiceIT.java
@@ -61,15 +61,20 @@ public class MRSPersonServiceIT extends BasePaxIT {
     public void shouldCreatePerson() {
 
         assertNotNull(person.getId());
-        assertEquals(person.getPersonId(), mrsListener.eventParameters.get(EventKeys.PERSON_ID));
-        assertEquals(person.getFirstName(), mrsListener.eventParameters.get(EventKeys.PERSON_FIRST_NAME));
-        assertEquals(person.getLastName(), mrsListener.eventParameters.get(EventKeys.PERSON_LAST_NAME));
+        assertEquals(mrsListener.eventParameters.get(EventKeys.PERSON_ID), person.getPersonId());
+        assertEquals(mrsListener.eventParameters.get(EventKeys.PERSON_FIRST_NAME), person.getFirstName());
+        assertEquals(mrsListener.eventParameters.get(EventKeys.PERSON_LAST_NAME), person.getLastName());
 
         assertTrue(mrsListener.created);
         assertFalse(mrsListener.deleted);
         assertFalse(mrsListener.updated);
     }
 
+    /*
+        We are able to convert fields from openMRS to single string field only for now
+        that is why we are checking assertTrue with contains function for changed address
+        rather than assertEquals for string field
+     */
     @Test
     public void shouldUpdatePerson() throws OpenMRSException, InterruptedException {
 
@@ -95,11 +100,11 @@ public class MRSPersonServiceIT extends BasePaxIT {
         updated = personAdapter.getPersonByUuid(person.getPersonId());
 
         assertNotNull(updated);
-        assertEquals(updated.getFirstName(), newFirstName);
-        assertEquals(updated.getMiddleName(), newMiddleName);
-        assertEquals(updated.getLastName(), newLastName);
-        assertEquals(updated.getAddress(), newAddress);
-        assertEquals(updated.getGender(), newGender);
+        assertEquals(newFirstName, updated.getFirstName());
+        assertEquals(newMiddleName, updated.getMiddleName());
+        assertEquals(newLastName, updated.getLastName());
+        assertTrue(updated.getAddress().contains(newAddress));
+        assertEquals(newGender, updated.getGender());
 
         assertTrue(mrsListener.created);
         assertTrue(mrsListener.updated);
@@ -127,7 +132,7 @@ public class MRSPersonServiceIT extends BasePaxIT {
         OpenMRSPerson fetched = personAdapter.getPersonByUuid(person.getPersonId());
 
         assertNotNull(fetched);
-        assertEquals(fetched.getId(), person.getId());
+        assertEquals(person.getId(), fetched.getId());
     }
 
     @After


### PR DESCRIPTION
1. Removed additional "," wich we didnt need in FullAddressString
2. Fixed arguments order in assertEquals function
3. Since we are able to convert addresses from openMRS to Motech representation only for now, I changed assert to check if address contains String rather than is equal to. that is best way to do it for now I belive. We will have to change that in future when we will be able to support openMRS address fully. 
