### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
Updating commons-collections from 3.2.1 to 3.2.2
due to vulnerabilities reported at:
https://commons.apache.org/proper/commons-collections/security-reports.html
