### PR TITLE
Changed rometools dependency to 1.5.99

### DIFF
--- a/atom-client/pom.xml
+++ b/atom-client/pom.xml
@@ -36,12 +36,10 @@
         <dependency>
             <groupId>com.rometools</groupId>
             <artifactId>rome-fetcher</artifactId>
-            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jdom</artifactId>
-            <version>2.0.6_1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,16 @@
                 <artifactId>groovy-all</artifactId>
                 <version>2.4.5</version>
             </dependency>
+            <dependency>
+                <groupId>com.rometools</groupId>
+                <artifactId>rome-fetcher</artifactId>
+                <version>1.5.99</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.servicemix.bundles</groupId>
+                <artifactId>org.apache.servicemix.bundles.jdom</artifactId>
+                <version>2.0.6_1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Missed that in the previous PR: :crying_cat_face: 
Also moved Atom Client module dependency versions to parent POM
