### PR TITLE
MOTECH-2295 Fixed Case XML parsing for namespaces

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/parser/CaseParser.java
+++ b/commcare/src/main/java/org/motechproject/commcare/parser/CaseParser.java
@@ -22,6 +22,8 @@ import java.io.StringReader;
  */
 public class CaseParser<T> {
 
+    private static final String NAMESPACE_WILDCARD = "*";
+
     private CaseMapper<T> domainMapper;
     private String xmlDoc;
     private String caseAction;
@@ -68,11 +70,11 @@ public class CaseParser<T> {
      * @return the created instance
      */
     public CaseXml parseCase(Document document) {
-        Element item = (Element) document.getElementsByTagName("case").item(0);
+        Element item = (Element) document.getElementsByTagNameNS(NAMESPACE_WILDCARD, "case").item(0);
         CaseXml ccCase = createCase(item);
         updateAction(ccCase, item);
 
-        Element dataItem = (Element) document.getElementsByTagName("data")
+        Element dataItem = (Element) document.getElementsByTagNameNS(NAMESPACE_WILDCARD, "data")
                 .item(0);
         updateDataFields(ccCase, dataItem);
 
@@ -145,7 +147,7 @@ public class CaseParser<T> {
 
     private String getTextValue(Element ele, String tagName) {
         String textVal = null;
-        NodeList nl = ele.getElementsByTagName(tagName);
+        NodeList nl = ele.getElementsByTagNameNS(NAMESPACE_WILDCARD, tagName);
         if (nl != null && nl.getLength() > 0) {
             Element el = (Element) nl.item(0);
             Node textNode = el.getFirstChild();
@@ -162,7 +164,7 @@ public class CaseParser<T> {
 
     private Node getMatchingNode(Element ele, String tagName) {
         Node element = null;
-        NodeList nl = ele.getElementsByTagName(tagName);
+        NodeList nl = ele.getElementsByTagNameNS(NAMESPACE_WILDCARD, tagName);
         if (nl != null && nl.getLength() > 0) {
             element = nl.item(0);
         }

--- a/commcare/src/test/java/org/motechproject/commcare/parser/CaseParserTest.java
+++ b/commcare/src/test/java/org/motechproject/commcare/parser/CaseParserTest.java
@@ -1,57 +1,127 @@
 package org.motechproject.commcare.parser;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.motechproject.commcare.domain.CaseXml;
 import org.motechproject.commcare.exception.CaseParserException;
 
 import java.io.FileNotFoundException;
 
-public class CaseParserTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+
+public class CaseParserTest {
 
     @Test
-    public void testShouldParseCaseAttributesCorrectly()
-            throws FileNotFoundException, CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                caseXml());
+    public void shouldParseCaseAttributesCorrectly() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(false));
         CaseXml aCase = parser.parseCase();
-        Assert.assertEquals("3F2504E04F8911D39A0C0305E82C3301",
+
+        assertEquals("3F2504E04F8911D39A0C0305E82C3301",
                 aCase.getCaseId());
-        Assert.assertEquals("2011-12-08T13:34:30", aCase.getDateModified());
-        Assert.assertEquals("F0183EDA012765103CB106821BBA51A0",
+        assertEquals("2011-12-08T13:34:30", aCase.getDateModified());
+        assertEquals("F0183EDA012765103CB106821BBA51A0",
                 aCase.getUserId());
-        Assert.assertEquals("2Z2504E04F8911D39A0C0305E82C3000",
+        assertEquals("2Z2504E04F8911D39A0C0305E82C3000",
                 aCase.getOwnerId());
     }
 
     @Test
-    public void testShouldParseCreateAttributesCorrectly()
-            throws FileNotFoundException, CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                caseXml());
+    public void shouldParseCreateAttributesCorrectly() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(false));
         CaseXml aCase = parser.parseCase();
-        Assert.assertEquals("houshold_rollout_ONICAF", aCase.getCaseType());
-        Assert.assertEquals("Smith", aCase.getCaseName());
+        assertEquals("houshold_rollout_ONICAF", aCase.getCaseType());
+        assertEquals("Smith", aCase.getCaseName());
     }
 
     @Test
-    public void testShouldFetchAPIKeyFromCaseXML()
-            throws FileNotFoundException, CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                caseXml());
+    public void shouldParseCaseAttributesCorrectlyForCaseWithNamespace() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(true));
         CaseXml aCase = parser.parseCase();
-        Assert.assertEquals("API_KEY", aCase.getApiKey());
+
+        assertEquals("3F2504E04F8911D39A0C0305E82C3301",
+                aCase.getCaseId());
+        assertEquals("2011-12-08T13:34:30", aCase.getDateModified());
+        assertEquals("F0183EDA012765103CB106821BBA51A0",
+                aCase.getUserId());
+        assertEquals("2Z2504E04F8911D39A0C0305E82C3000",
+                aCase.getOwnerId());
     }
 
     @Test
-    public void testShouldParseCloseAttributesCorrectly()
-            throws FileNotFoundException, CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
+    public void shouldParseCreateAttributesCorrectlyForCaseWithNamespace() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(true));
+        CaseXml aCase = parser.parseCase();
+        assertEquals("houshold_rollout_ONICAF", aCase.getCaseType());
+        assertEquals("Smith", aCase.getCaseName());
+    }
+
+    @Test
+    public void shouldFetchAPIKeyFromCaseXML() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(false));
+        CaseXml aCase = parser.parseCase();
+        assertEquals("API_KEY", aCase.getApiKey());
+    }
+
+    @Test
+    public void shouldParseCloseAttributesCorrectly() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class,
                 caseXmlForClose());
         CaseXml aCase = parser.parseCase();
         assertEquals("CLOSE", parser.getCaseAction());
         assertEquals("3F2504E04F8911D39A0C0305E82C3301", aCase.getCaseId());
+    }
+
+    @Test
+    public void shouldSetActionCorrectly() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXml(false));
+        CaseXml aCase = parser.parseCase();
+        assertEquals("CREATE", aCase.getAction());
+    }
+
+    @Test
+    public void shouldParseIndexElementCorrectly() throws FileNotFoundException, CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, childXml());
+        CaseXml aCase = parser.parseCase();
+        assertEquals("45134cf7-90f8-4284-8ca1-16392fc0ce57",
+                aCase.getCaseId());
+        assertEquals("2012-04-03", aCase.getDateModified());
+        assertEquals("d823ea3d392a06f8b991e9e4933348bd",
+                aCase.getUserId());
+        assertEquals("d823ea3d392a06f8b991e9e49394ce45",
+                aCase.getOwnerId());
+        assertEquals("motherCaseId",
+                aCase.getFieldValues().get("mother_id"));
+    }
+
+    @Test
+    public void shouldParseDataXmlns() throws CaseParserException {
+        CaseParser<CaseXml> parser = new CaseParser<>(CaseXml.class, caseXmlWithDataTag());
+        CaseXml aCase = parser.parseCase();
+
+        assertEquals("3F2504E04F8911D39A0C0305E82C3301", aCase.getCaseId());
+        assertEquals("2011-12-08T13:34:30", aCase.getDateModified());
+        assertEquals("F0183EDA012765103CB106821BBA51A0", aCase.getUserId());
+        assertEquals("2Z2504E04F8911D39A0C0305E82C3000", aCase.getOwnerId());
+
+        assertEquals("http://myDomain.com/test/ns", aCase.getCaseDataXmlns());
+    }
+
+    private String caseXml(boolean withNamespace) {
+        String namespace = withNamespace ? "n0:" : StringUtils.EMPTY;
+
+        String caseXml = "<" + namespace + "case xmlns" + (withNamespace ? ":n0" : StringUtils.EMPTY) + "=\"http://commcarehq.org/case/transaction/v2\" case_id=\"3F2504E04F8911D39A0C0305E82C3301\" user_id=\"F0183EDA012765103CB106821BBA51A0\" date_modified=\"2011-12-08T13:34:30\" api_key=\"API_KEY\" >\n"
+                + "<" + namespace + "create>"
+                + "<"+ namespace + "case_type>houshold_rollout_ONICAF</"+ namespace + "case_type>"
+                + "<"+ namespace + "case_name>Smith</" + namespace + "case_name>"
+                + "<"+ namespace + "owner_id>2Z2504E04F8911D39A0C0305E82C3000</" + namespace + "owner_id>"
+                + "</"+ namespace + "create>"
+                + "<"+ namespace + "update>"
+                + "<"+ namespace + "household_id>24/F23/3</"+ namespace + "household_id>"
+                + "<"+ namespace + "primary_contact_name>Tom Smith</" + namespace + "primary_contact_name>"
+                + "<"+ namespace + "visit_number>1</"+ namespace + "visit_number>" + "</" + namespace + "update>" + "</" + namespace + "case>";
+
+        return caseXml;
     }
 
     private String caseXmlForClose() {
@@ -60,64 +130,9 @@ public class CaseParserTest extends TestCase {
                 + "    <close />" + "</case>";
     }
 
-    @Test
-    public void testShouldSetActionCorrectly() throws FileNotFoundException,
-            CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                caseXml());
-        CaseXml aCase = parser.parseCase();
-        Assert.assertEquals("CREATE", aCase.getAction());
-    }
-
-    @Test
-    public void testShouldParseIndexElementCorrectly()
-            throws FileNotFoundException, CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                childXml());
-        CaseXml aCase = parser.parseCase();
-        Assert.assertEquals("45134cf7-90f8-4284-8ca1-16392fc0ce57",
-                aCase.getCaseId());
-        Assert.assertEquals("2012-04-03", aCase.getDateModified());
-        Assert.assertEquals("d823ea3d392a06f8b991e9e4933348bd",
-                aCase.getUserId());
-        Assert.assertEquals("d823ea3d392a06f8b991e9e49394ce45",
-                aCase.getOwnerId());
-        Assert.assertEquals("motherCaseId",
-                aCase.getFieldValues().get("mother_id"));
-    }
-
-    @Test
-    public void shouldParseDataXmlns() throws CaseParserException {
-        CaseParser<CaseXml> parser = new CaseParser<CaseXml>(CaseXml.class,
-                caseXmlWithDataTag());
-        CaseXml aCase = parser.parseCase();
-
-        Assert.assertEquals("3F2504E04F8911D39A0C0305E82C3301", aCase.getCaseId());
-        Assert.assertEquals("2011-12-08T13:34:30", aCase.getDateModified());
-        Assert.assertEquals("F0183EDA012765103CB106821BBA51A0", aCase.getUserId());
-        Assert.assertEquals("2Z2504E04F8911D39A0C0305E82C3000", aCase.getOwnerId());
-
-        Assert.assertEquals("http://myDomain.com/test/ns", aCase.getCaseDataXmlns());
-    }
-
-    private String caseXml() {
-        String caseXml = "<case xmlns=\"http://commcarehq.org/case/transaction/v2\" case_id=\"3F2504E04F8911D39A0C0305E82C3301\" user_id=\"F0183EDA012765103CB106821BBA51A0\" date_modified=\"2011-12-08T13:34:30\" api_key=\"API_KEY\" >\n"
-                + "<create>"
-                + "<case_type>houshold_rollout_ONICAF</case_type>"
-                + "<case_name>Smith</case_name>"
-                + "<owner_id>2Z2504E04F8911D39A0C0305E82C3000</owner_id>"
-                + "</create>"
-                + "<update>"
-                + "<household_id>24/F23/3</household_id>"
-                + "<primary_contact_name>Tom Smith</primary_contact_name>"
-                + "<visit_number>1</visit_number>" + "</update>" + "</case>";
-
-        return caseXml;
-    }
-
     private String caseXmlWithDataTag() {
         return "<data xmlns=\"http://myDomain.com/test/ns\"><meta><userID>fb6e0b19cbe3ef683a10c4c4766a1ef3</userID></meta>"
-                + caseXml() + "</data>";
+                + caseXml(false) + "</data>";
     }
 
     private String childXml() {


### PR DESCRIPTION
The parsing of a case XML would not work properly if the XML sent to
MOTECH would contain elements with namespaces (eg. `
<n0:case> ...
</n0:case>
` , instead of `<case> ... </case>`). This has been fixed and the
parsing will work properly for elements with and without namespace.
