### PR TITLE
MOTECH-2305: In IVR: Fixed cleaning configuration pre integration test

### DIFF
--- a/ivr/pom.xml
+++ b/ivr/pom.xml
@@ -163,17 +163,27 @@
                     <plugin>
                         <artifactId>maven-clean-plugin</artifactId>
                         <version>2.6.1</version>
-                        <configuration>
-                            <filesets>
-                                <fileset>
-                                    <directory>${motech.dir}/config/org.motechproject.ivr/raw</directory>
-                                    <includes>
-                                        <include>*.json</include>
-                                    </includes>
-                                    <followSymlinks>false</followSymlinks>
-                                </fileset>
-                            </filesets>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>clean-config</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${motech.dir}/config/org.motechproject.ivr/raw</directory>
+                                            <includes>
+                                                <include>*.json</include>
+                                            </includes>
+                                            <followSymlinks>false</followSymlinks>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
To make cleaning configuration work I added in IT profile, for clean-plugin, execution tag. Now this plugin will be executed with -PIT. Old IVR configuration will be deleted before test, because of I added phase pre-integration-test.
