### PR TITLE
MOTECH-2469: Fixed javadoc issue with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1063,6 +1063,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixed javadoc parsing issues for JDK 8.
