### PR TITLE
MOTECH-2364: Upgraded OpenMRS module to OpenMRS 1.12 (for Bahmni).

### DIFF
--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/Encounter.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/Encounter.java
@@ -18,8 +18,9 @@ public class Encounter {
     private Date encounterDatetime;
     private Patient patient;
     private Person provider;
-    private List<Person> encounterProviders;
     private List<Observation> obs;
+    //This field is new in OpenMRS since version 1.10
+    private List<Person> encounterProviders;
 
     /**
      * Default constructor.

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/Encounter.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/domain/Encounter.java
@@ -18,6 +18,7 @@ public class Encounter {
     private Date encounterDatetime;
     private Patient patient;
     private Person provider;
+    private List<Person> encounterProviders;
     private List<Observation> obs;
 
     /**
@@ -95,6 +96,14 @@ public class Encounter {
 
     public void setProvider(Person provider) {
         this.provider = provider;
+    }
+
+    public List<Person> getEncounterProviders() {
+        return encounterProviders;
+    }
+
+    public void setEncounterProviders(List<Person> encounterProviders) {
+        this.encounterProviders = encounterProviders;
     }
 
     public List<Observation> getObs() {

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/EncounterResourceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/EncounterResourceImpl.java
@@ -31,7 +31,7 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
         String responseJson = postForJson(config, requestJson, "/encounter?v=full");
 
         Encounter createdEncounter = (Encounter) JsonUtils.readJson(responseJson, Encounter.class);
-        getProviderFromEncounterProviderList(createdEncounter);
+        setProviderFromEncounterProviderList(createdEncounter);
         return createdEncounter;
     }
 
@@ -41,7 +41,7 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
         
         EncounterListResult encounterList = (EncounterListResult) JsonUtils.readJson(responseJson, EncounterListResult.class);
         for(Encounter encounter : encounterList.getResults()) {
-            getProviderFromEncounterProviderList(encounter);
+            setProviderFromEncounterProviderList(encounter);
         }
         return encounterList;
     }
@@ -51,7 +51,7 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
         String responseJson = getJson(config, "/encounter/{uuid}?v=full", uuid);
 
         Encounter createdEncounter = (Encounter) JsonUtils.readJson(responseJson, Encounter.class);
-        getProviderFromEncounterProviderList(createdEncounter);
+        setProviderFromEncounterProviderList(createdEncounter);
         return createdEncounter;
     }
 
@@ -94,12 +94,12 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
     }
 
     /**
-     * Rewrites provider from the list to single provider object in encounter. Since OpenMRS version 1.10
-     * providers in encounter are stored on the list.
+     * Sets provider from the list to a single provider object in encounter. Since OpenMRS version 1.10
+     * providers in encounter are stored as a list.
      *
      * @param encounter
      */
-    private void getProviderFromEncounterProviderList(Encounter encounter) {
+    private void setProviderFromEncounterProviderList(Encounter encounter) {
         if (encounter.getProvider() == null && CollectionUtils.isNotEmpty(encounter.getEncounterProviders())) {
             encounter.setProvider(encounter.getEncounterProviders().get(0));
         }

--- a/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/EncounterResourceImpl.java
+++ b/openmrs-19/src/main/java/org/motechproject/openmrs19/resource/impl/EncounterResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs19.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.collections.CollectionUtils;
 import org.motechproject.openmrs19.config.Config;
 import org.motechproject.openmrs19.domain.Encounter;
 import org.motechproject.openmrs19.domain.EncounterListResult;
@@ -92,9 +93,14 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
                 .create();
     }
 
+    /**
+     * Rewrites provider from the list to single provider object in encounter. Since OpenMRS version 1.10
+     * providers in encounter are stored on the list.
+     *
+     * @param encounter
+     */
     private void getProviderFromEncounterProviderList(Encounter encounter) {
-        //When OpenMRS version is 1.12, then providers are stored on the list.
-        if(encounter.getProvider()==null && !encounter.getEncounterProviders().isEmpty()) {
+        if (encounter.getProvider() == null && CollectionUtils.isNotEmpty(encounter.getEncounterProviders())) {
             encounter.setProvider(encounter.getEncounterProviders().get(0));
         }
     }


### PR DESCRIPTION
OpenMRS v1.12 'get encounter' returns encounter with provider stored on the list, but OpenMRS v1.9 returns encounter with single provider object . I implemented method which rewrites provider from list to single provider object. Sending encounter in both versions works the same way.
