### PR TITLE
MOTECH-2420 Unschedule unsupported OpenMRS Programs IT

### DIFF
--- a/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSIntegrationTests.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSIntegrationTests.java
@@ -14,6 +14,6 @@ import org.motechproject.openmrs.it.MRSUserServiceIT;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({MRSConceptServiceIT.class, MRSEncounterServiceIT.class, MRSLocationServiceIT.class,
         MRSObservationServiceIT.class, MRSPatientServiceIT.class, MRSPersonServiceIT.class, MRSProviderServiceIT.class,
-        MRSUserServiceIT.class, MRSProgramEnrollmentIT.class})
+        MRSUserServiceIT.class})
 public class MRSIntegrationTests {
 }


### PR DESCRIPTION
So far our OpenMRS docker 1.12 on Nufu server does not have required instances in database for Programs ITs. We will enable this ITs for OpenMRS 1.12 after adding them to docker
