### PR TITLE
MOTECH-2228: fix retreving data in dhis2 release 2.22

### DIFF
--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ProgramStageDataElementDto.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ProgramStageDataElementDto.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ProgramStageDataElementDto {
+public class ProgramStageDataElementDto extends BaseDto {
 
     private ProgramStageDto programStage;
     private DataElementDto dataElement;

--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ProgramTrackedEntityAttributeDto.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ProgramTrackedEntityAttributeDto.java
@@ -8,7 +8,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ProgramTrackedEntityAttributeDto {
+public class ProgramTrackedEntityAttributeDto extends BaseDto{
 
     private TrackedEntityAttributeDto trackedEntityAttribute;
 

--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ServerVersion.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/domain/ServerVersion.java
@@ -9,6 +9,7 @@ public class ServerVersion {
     public static final String V2_18 = "2.18";
     public static final String V2_19 = "2.19";
     public static final String V2_21 = "2.21";
+    public static final String V2_22 = "2.22";
 
     private String version;
 

--- a/dhis2/src/main/java/org/motechproject/dhis2/rest/service/DhisWebService.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/rest/service/DhisWebService.java
@@ -10,7 +10,9 @@ import org.motechproject.dhis2.rest.domain.DhisStatusResponse;
 import org.motechproject.dhis2.rest.domain.EnrollmentDto;
 import org.motechproject.dhis2.rest.domain.OrganisationUnitDto;
 import org.motechproject.dhis2.rest.domain.ProgramDto;
+import org.motechproject.dhis2.rest.domain.ProgramStageDataElementDto;
 import org.motechproject.dhis2.rest.domain.ProgramStageDto;
+import org.motechproject.dhis2.rest.domain.ProgramTrackedEntityAttributeDto;
 import org.motechproject.dhis2.rest.domain.ServerVersion;
 import org.motechproject.dhis2.rest.domain.TrackedEntityAttributeDto;
 import org.motechproject.dhis2.rest.domain.TrackedEntityDto;
@@ -36,24 +38,38 @@ public interface DhisWebService {
     List<DataSetDto> getDataSets();
 
     /**
-     * Gets the Data Element specified in the URL
+     * Gets the Data Element specified in the URL.
      * @param href
      * @return the {@link org.motechproject.dhis2.rest.domain.DataElementDto}
      */
     DataElementDto getDataElementByHref(String href);
 
     /**
-     * Gets a list of all the Organisation Units from DHIS2
+     * Gets the Data Element specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.DataElementDto}
+     */
+    DataElementDto getDataElementById(String id);
+
+    /**
+     * Gets a list of all the Organisation Units from DHIS2.
      * @return a list of {@link org.motechproject.dhis2.rest.domain.OrganisationUnitDto}
      */
     List<OrganisationUnitDto> getOrganisationUnits();
 
     /**
-     * Gets the Organisation Unit specified in the URL
+     * Gets the Organisation Unit specified in the URL.
      * @param href
      * @return the {@link org.motechproject.dhis2.rest.domain.OrganisationUnitDto}
      */
     OrganisationUnitDto getOrganisationUnitByHref(String href);
+
+    /**
+     * Gets the Organisation Unit specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.OrganisationUnitDto}
+     */
+    OrganisationUnitDto getOrganisationUnitById(String id);
 
     /**
      * Gets a list of all the programs from DHIS2.
@@ -62,40 +78,89 @@ public interface DhisWebService {
     List<ProgramDto> getPrograms();
 
     /**
-     * Gets the program specified in the URL
+     * Gets the program specified in the URL.
      * @param href
      * @return the {@link org.motechproject.dhis2.rest.domain.ProgramDto}
      */
     ProgramDto getProgramByHref(String href);
 
     /**
-     * Gets a list of all the program Stages from DHIS2
+     * Gets the program specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.ProgramDto}
+     */
+    ProgramDto getProgramById(String id);
+
+    /**
+     * Gets a list of all the program Stages from DHIS2.
      * @return a list of {@link org.motechproject.dhis2.rest.domain.ProgramStageDto\}
      */
     List<ProgramStageDto> getProgramStages();
 
     /**
-     * Gets the program stage specified in the URL
+     * Gets the program Stage specified in the URL.
      * @param href
      * @return the {@link org.motechproject.dhis2.rest.domain.ProgramStageDto}
      */
     ProgramStageDto getProgramStageByHref(String href);
 
     /**
-     * Gets a list of all the tracked entity attributes from DHIS2
+     * Gets the program Stage Data Element specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.ProgramStageDataElementDto}
+     */
+    ProgramStageDataElementDto getProgramStageDataElementById(String id);
+
+    /**
+     * Gets the program Stage Data Element specified in the URL.
+     * @param href
+     * @return the {@link org.motechproject.dhis2.rest.domain.ProgramStageDataElementDto}
+     */
+    ProgramStageDataElementDto getProgramStageDataElementByHref(String href);
+
+    /**
+     * Gets the program Stage specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.ProgramStageDto}
+     */
+    ProgramStageDto getProgramStageById(String id);
+
+    /**
+     * Gets a list of all the tracked entity attributes from DHIS2.
      * @return a list of {@link org.motechproject.dhis2.rest.domain.TrackedEntityInstanceDto}
      */
     List<TrackedEntityAttributeDto> getTrackedEntityAttributes();
 
     /**
-     * Gets the tracked entity attribute specified in the URL
+     * Gets the tracked entity attribute specified in the URL.
      * @param href
      * @return the {@link org.motechproject.dhis2.rest.domain.TrackedEntityAttributeDto}
      */
     TrackedEntityAttributeDto getTrackedEntityAttributeByHref(String href);
 
     /**
-     * Gets a list of all the tracked entity types in DHIS2
+     * Gets the tracked entity attribute specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.TrackedEntityAttributeDto}
+     */
+    TrackedEntityAttributeDto getTrackedEntityAttributeById(String id);
+
+    /**
+     * Gets the tracked entity attribute specified in the URL.
+     * @param href
+     * @return the {@link org.motechproject.dhis2.rest.domain.TrackedEntityAttributeDto}
+     */
+    ProgramTrackedEntityAttributeDto getProgramTrackedEntityAttributeByHref(String href);
+
+    /**
+     * Gets the tracked entity attribute specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.TrackedEntityAttributeDto}
+     */
+    ProgramTrackedEntityAttributeDto getProgramTrackedEntityAttributeById(String id);
+
+    /**
+     * Gets a list of all the tracked entity types in DHIS2.
      * @return a list of {@link org.motechproject.dhis2.rest.domain.TrackedEntityDto}
      */
     List<TrackedEntityDto> getTrackedEntities();
@@ -108,21 +173,28 @@ public interface DhisWebService {
     TrackedEntityDto getTrackedEntityByHref(String href);
 
     /**
-     * Attempts to create an enrollment in DHIS2 via an HTTP post request
+     * Gets the tracked entity specified by ID.
+     * @param id
+     * @return the {@link org.motechproject.dhis2.rest.domain.TrackedEntityDto}
+     */
+    TrackedEntityDto getTrackedEntityById(String id);
+
+    /**
+     * Attempts to create an enrollment in DHIS2 via an HTTP post request.
      * @param enrollmentDto
      * @return a {@link org.motechproject.dhis2.rest.domain.DhisStatusResponse} indicating success or failure
      */
     DhisStatusResponse createEnrollment(EnrollmentDto enrollmentDto);
 
     /**
-     * Attempts to create a DHIS2 event in DHIS2 via an HTTP post request
+     * Attempts to create a DHIS2 event in DHIS2 via an HTTP post request.
      * @param event
      * @return a {@link org.motechproject.dhis2.rest.domain.DhisStatusResponse} indicating success or failure
      */
     DhisStatusResponse createEvent(DhisEventDto event);
 
     /**
-     * Attempts to create a tracked entity instance in DHIS2 via an HTTP post request
+     * Attempts to create a tracked entity instance in DHIS2 via an HTTP post request.
      * @param trackedEntity
      * @returna {@link org.motechproject.dhis2.rest.domain.DhisStatusResponse} indicating success or failure
      */

--- a/dhis2/src/main/java/org/motechproject/dhis2/service/impl/SyncServiceImpl.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/service/impl/SyncServiceImpl.java
@@ -140,7 +140,12 @@ public class SyncServiceImpl implements SyncService {
         List<ProgramDto> partialDtos = dhisWebService.getPrograms();
 
         for (ProgramDto partialDto : partialDtos) {
-            ProgramDto fullDto = dhisWebService.getProgramByHref(partialDto.getHref());
+            ProgramDto fullDto;
+            if (partialDto.getHref() == null) {
+                fullDto = dhisWebService.getProgramById(partialDto.getId());
+            } else {
+                fullDto = dhisWebService.getProgramByHref(partialDto.getHref());
+            }
             Program program = programService.createFromDetails(fullDto);
 
             /**
@@ -169,7 +174,12 @@ public class SyncServiceImpl implements SyncService {
     private TrackedEntity getProgramTrackedEntityFromDto(TrackedEntityDto partialDto) {
         TrackedEntity trackedEntity = trackedEntityService.findById(partialDto.getId());
         if (trackedEntity == null) {
-            TrackedEntityDto fullDto = dhisWebService.getTrackedEntityByHref(partialDto.getHref());
+            TrackedEntityDto fullDto;
+            if (partialDto.getHref() == null) {
+                fullDto = dhisWebService.getTrackedEntityById(partialDto.getId());
+            } else {
+                fullDto = dhisWebService.getTrackedEntityByHref(partialDto.getHref());
+            }
             trackedEntity = trackedEntityService.createFromDetails(fullDto);
         }
         return trackedEntity;
@@ -187,7 +197,12 @@ public class SyncServiceImpl implements SyncService {
             Stage stage = stageService.findById(partialStageDto.getId());
 
             if (stage == null) {
-                ProgramStageDto fullDto = dhisWebService.getProgramStageByHref(partialStageDto.getHref());
+                ProgramStageDto fullDto;
+                if (partialStageDto.getHref() == null) {
+                    fullDto = dhisWebService.getProgramStageById(partialStageDto.getId());
+                } else {
+                    fullDto = dhisWebService.getProgramStageByHref(partialStageDto.getHref());
+                }
                 stage = stageService.createFromDetails(fullDto, programId, hasRegistration);
                 stage.setDataElements(getStageDataElementsFromDtos(fullDto.getProgramStageDataElements()));
             }
@@ -205,7 +220,14 @@ public class SyncServiceImpl implements SyncService {
         List<DataElement> dataElements = new ArrayList<DataElement>();
 
         for (ProgramStageDataElementDto programStageDataElementDto : programStageDataElementDtos) {
+            if (programStageDataElementDto.getDataElement() == null && programStageDataElementDto.getId() != null) {
+                programStageDataElementDto = dhisWebService.getProgramStageDataElementById(programStageDataElementDto.getId());
+            }
+
             DataElementDto dataElementDto = programStageDataElementDto.getDataElement();
+            if (dataElementDto.getId() != null) {
+                dataElementDto = dhisWebService.getDataElementById(dataElementDto.getId());
+            }
             if (dataElementDto != null) {
                 DataElement dataElement = dataElementService.findById(dataElementDto.getId());
                 if (dataElement == null) {
@@ -226,9 +248,15 @@ public class SyncServiceImpl implements SyncService {
         List<TrackedEntityAttribute> trackedEntityAttributes = new ArrayList<TrackedEntityAttribute>();
 
         for (ProgramTrackedEntityAttributeDto programTrackedEntityAttributeDto : programTrackedEntityAttributeDtos) {
+            if (programTrackedEntityAttributeDto.getTrackedEntityAttribute() == null && programTrackedEntityAttributeDto.getId() != null) {
+                programTrackedEntityAttributeDto = dhisWebService.getProgramTrackedEntityAttributeById(programTrackedEntityAttributeDto.getId());
+            }
             TrackedEntityAttributeDto trackedEntityAttributeDto = programTrackedEntityAttributeDto.getTrackedEntityAttribute();
             TrackedEntityAttribute trackedEntityAttribute = trackedEntityAttributeService.findById(trackedEntityAttributeDto.getId());
             if (trackedEntityAttribute == null) {
+                if (programTrackedEntityAttributeDto.getId() != null) {
+                    trackedEntityAttributeDto = dhisWebService.getTrackedEntityAttributeById(programTrackedEntityAttributeDto.getId());
+                }
                 trackedEntityAttribute = trackedEntityAttributeService.createFromDetails(trackedEntityAttributeDto);
             }
             trackedEntityAttributes.add(trackedEntityAttribute);

--- a/dhis2/src/main/resources/webapp/js/controllers.js
+++ b/dhis2/src/main/resources/webapp/js/controllers.js
@@ -127,7 +127,7 @@
         innerLayout({});
     });
 
-    controllers.controller('Dhis2TrackedEntitiesCtrl', function($scope, TrackedEntitie, LoadingModal) {
+    controllers.controller('Dhis2TrackedEntitiesCtrl', function($scope, TrackedEntities, LoadingModal) {
         LoadingModal.open();
         $scope.trackedEntities = TrackedEntities.query(function() {
             LoadingModal.close();

--- a/dhis2/src/main/resources/webapp/partials/settings.html
+++ b/dhis2/src/main/resources/webapp/partials/settings.html
@@ -52,8 +52,8 @@
                 {{msg('dhis2.sync')}}
             </button>
             <div ng-show="blocked" class ="alert alert-info">{{msg('dhis2.sync.wait')}}</div>
-            <div ng-show="success == 'true' " class ="alert alert-success">{{msg('dhis2.sync.success')}}</div>
-            <div ng-show="success == 'false' " class ="alert alert-danger">{{msg('dhis2.sync.fail')}}</div>
+            <div ng-show="success == true" class ="alert alert-success">{{msg('dhis2.sync.success')}}</div>
+            <div ng-show="success == false" class ="alert alert-danger">{{msg('dhis2.sync.fail')}}</div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- there was a change in retrieve list of objects in DHIS 2.22 release, now server replies only with id and display name instead of full data object, especially there was lack of href attribute so it was impossible to retrieve detailed information about object in list; to get full object information while getting list of them api requires to add "?fields=:identifiable" filter at the end of URL, another solution is to get information for every single object
- also fixed typo in DHIS2 contollers.js, that causes error in browser console and empty table of Tracked Entities

for checking api changes view [2.22](https://www.dhis2.org/222-upgrade)
