### PR TITLE
MOTECH-2738 Clear cookies before sending request

### DIFF
--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/BaseResource.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/BaseResource.java
@@ -89,6 +89,7 @@ public abstract class BaseResource {
     private ResponseEntity<String> exchange(Config config, URI url, HttpMethod method, String body, HttpHeaders headers) {
         headers.add("Authorization", "Basic " + prepareCredentials(config));
 
+        //Clear cookies to avoid SESSIONID mismatch
         httpClient.getState().clearCookies();
 
         return restOperations.exchange(url, method, new HttpEntity<>(body, headers), String.class);

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/BaseResource.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/BaseResource.java
@@ -1,6 +1,7 @@
 package org.motechproject.openmrs.resource.impl;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,9 +20,11 @@ import java.util.Arrays;
 public abstract class BaseResource {
 
     private RestOperations restOperations;
+    private HttpClient httpClient;
 
-    protected BaseResource(RestOperations restOperations) {
+    protected BaseResource(RestOperations restOperations, HttpClient httpClient) {
         this.restOperations = restOperations;
+        this.httpClient = httpClient;
     }
 
     /**
@@ -85,6 +88,9 @@ public abstract class BaseResource {
 
     private ResponseEntity<String> exchange(Config config, URI url, HttpMethod method, String body, HttpHeaders headers) {
         headers.add("Authorization", "Basic " + prepareCredentials(config));
+
+        httpClient.getState().clearCookies();
+
         return restOperations.exchange(url, method, new HttpEntity<>(body, headers), String.class);
     }
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ConceptResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ConceptResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.lang.Validate;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Concept;
@@ -20,8 +21,8 @@ public class ConceptResourceImpl extends BaseResource implements ConceptResource
     private static final String GET_CONCEPTS_PATH = "/concept?v=full&limit={pageSize}&startIndex={startIndex}";
 
     @Autowired
-    public ConceptResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public ConceptResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/EncounterResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/EncounterResourceImpl.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Encounter;
 import org.motechproject.openmrs.domain.EncounterListResult;
@@ -26,8 +27,8 @@ public class EncounterResourceImpl extends BaseResource implements EncounterReso
     private static final String OPENMRS_V19 = "1.9";
 
     @Autowired
-    public EncounterResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public EncounterResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/LocationResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/LocationResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.lang.Validate;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Location;
@@ -18,8 +19,8 @@ public class LocationResourceImpl extends BaseResource implements LocationResour
     private static final String GET_LOCATIONS_PATH = "/location?v=full&limit={pageSize}&startIndex={startIndex}";
 
     @Autowired
-    public LocationResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public LocationResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ObservationResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ObservationResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.lang.StringUtils;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Concept;
@@ -18,8 +19,8 @@ import org.springframework.web.client.RestOperations;
 public class ObservationResourceImpl extends BaseResource implements ObservationResource {
 
     @Autowired
-    public ObservationResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public ObservationResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/PatientResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/PatientResourceImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.lang.StringUtils;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Identifier;
@@ -29,8 +30,8 @@ public class PatientResourceImpl extends BaseResource implements PatientResource
     private BiMap<String, String> identifierTypeUuidByName = HashBiMap.create();
 
     @Autowired
-    public PatientResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public PatientResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/PersonResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/PersonResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Attribute;
 import org.motechproject.openmrs.domain.AttributeTypeListResult;
@@ -17,8 +18,8 @@ import org.springframework.web.client.RestOperations;
 public class PersonResourceImpl extends BaseResource implements PersonResource {
 
     @Autowired
-    public PersonResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public PersonResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.ProgramEnrollmentListResult;
 import org.motechproject.openmrs.domain.Location;
@@ -20,8 +21,8 @@ import java.util.List;
 public class ProgramEnrollmentResourceImpl extends BaseResource implements ProgramEnrollmentResource {
 
     @Autowired
-    protected ProgramEnrollmentResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    protected ProgramEnrollmentResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProviderResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProviderResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Person;
 import org.motechproject.openmrs.domain.Provider;
@@ -15,8 +16,8 @@ import org.springframework.web.client.RestOperations;
 public class ProviderResourceImpl extends BaseResource implements ProviderResource {
 
     @Autowired
-    public ProviderResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public ProviderResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/RelationshipResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/RelationshipResourceImpl.java
@@ -1,5 +1,6 @@
 package org.motechproject.openmrs.resource.impl;
 
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.RelationshipListResult;
 import org.motechproject.openmrs.resource.RelationshipResource;
@@ -12,8 +13,8 @@ import org.springframework.web.client.RestOperations;
 public class RelationshipResourceImpl extends BaseResource implements RelationshipResource {
 
     @Autowired
-    public RelationshipResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public RelationshipResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/UserResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/UserResourceImpl.java
@@ -2,6 +2,7 @@ package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.httpclient.HttpClient;
 import org.motechproject.openmrs.config.Config;
 import org.motechproject.openmrs.domain.Person;
 import org.motechproject.openmrs.domain.Role;
@@ -18,8 +19,8 @@ import org.springframework.web.client.RestOperations;
 public class UserResourceImpl extends BaseResource implements UserResource {
 
     @Autowired
-    public UserResourceImpl(RestOperations restOperations) {
-        super(restOperations);
+    public UserResourceImpl(RestOperations restOperations, HttpClient httpClient) {
+        super(restOperations, httpClient);
     }
 
     @Override

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ConceptResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ConceptResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +37,9 @@ public class ConceptResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -45,7 +50,9 @@ public class ConceptResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        conceptResource = new ConceptResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        conceptResource = new ConceptResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/EncounterResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/EncounterResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,6 +47,9 @@ public class EncounterResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -55,7 +60,9 @@ public class EncounterResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        encounterResource = new EncounterResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        encounterResource = new EncounterResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/LocationResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/LocationResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +37,9 @@ public class LocationResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -45,7 +50,9 @@ public class LocationResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        locationResource = new LocationResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        locationResource = new LocationResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ObservationResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ObservationResourceImplTest.java
@@ -1,5 +1,7 @@
 package org.motechproject.openmrs.resource.impl;
 
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.motechproject.openmrs.domain.ObservationListResult;
@@ -30,6 +32,9 @@ public class ObservationResourceImplTest extends AbstractResourceImplTest {
 
     @Mock
     private RestOperations restOperations;
+    @Mock
+    private HttpClient httpClient;
+
 
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
@@ -41,7 +46,9 @@ public class ObservationResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        observationResource = new ObservationResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        observationResource = new ObservationResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/PatientResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/PatientResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -40,6 +42,9 @@ public class PatientResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -50,7 +55,9 @@ public class PatientResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        patientResource = new PatientResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        patientResource = new PatientResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/PersonResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/PersonResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,6 +41,9 @@ public class PersonResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -49,7 +54,9 @@ public class PersonResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        personResource = new PersonResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        personResource = new PersonResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -36,6 +38,9 @@ public class ProgramEnrollmentResourceImplTest extends AbstractResourceImplTest 
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -46,7 +51,9 @@ public class ProgramEnrollmentResourceImplTest extends AbstractResourceImplTest 
     @Before
     public void setUp() {
         initMocks(this);
-        programEnrollmentResource = new ProgramEnrollmentResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        programEnrollmentResource = new ProgramEnrollmentResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/RelationshipResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/RelationshipResourceImplTest.java
@@ -1,5 +1,7 @@
 package org.motechproject.openmrs.resource.impl;
 
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +32,9 @@ public class RelationshipResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -40,7 +45,9 @@ public class RelationshipResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        relationshipResource = new RelationshipResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+
+        relationshipResource = new RelationshipResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/UserResourceImplTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/resource/impl/UserResourceImplTest.java
@@ -1,6 +1,8 @@
 package org.motechproject.openmrs.resource.impl;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,6 +41,9 @@ public class UserResourceImplTest extends AbstractResourceImplTest {
     @Mock
     private RestOperations restOperations;
 
+    @Mock
+    private HttpClient httpClient;
+
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
 
@@ -49,7 +54,9 @@ public class UserResourceImplTest extends AbstractResourceImplTest {
     @Before
     public void setUp() {
         initMocks(this);
-        userResource = new UserResourceImpl(restOperations);
+        when(httpClient.getState()).thenReturn(new HttpState());
+        
+        userResource = new UserResourceImpl(restOperations, httpClient);
         config = ConfigDummyData.prepareConfig("one");
     }
 


### PR DESCRIPTION
OpenMRS use basic HTTP authentication, but it also creates a cookie to keep user session. However this cookie doesn't have an expiration time. If server discards session, any request with session cookie will return "403" code. Our requests use basic authentication, so they don't need session cookie at all. To avoid problems with session timeout, I remove all cookies and rely only on basic authentication.
