### PR TITLE
MOTECH-2754: OpenMRS Task Data Source Program enrollment - Add 'only get active programs' to lookups

### DIFF
--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollment.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollment.java
@@ -172,11 +172,6 @@ public class ProgramEnrollment {
         this.enrolled = enrolled;
     }
 
-    //todo: MOTECH-2203
-    public String getEnrolledString() {
-        return enrolled ? ENROLLED : NOT_ENROLLED;
-    }
-
     public StateStatus getCurrentState() {
         StateStatus result = null;
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
@@ -10,12 +10,22 @@ public class ProgramEnrollmentListResult {
 
     private List<ProgramEnrollment> results;
 
+    private Integer numberOfPrograms;
+
     public List<ProgramEnrollment> getResults() {
         return results;
     }
 
+    public Integer getNumberOfPrograms() {
+        return numberOfPrograms;
+    }
+
     public void setResults(List<ProgramEnrollment> results) {
         this.results = results;
+    }
+
+    public void setNumberOfPrograms(Integer size) {
+        numberOfPrograms = size;
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
@@ -10,22 +10,18 @@ public class ProgramEnrollmentListResult {
 
     private List<ProgramEnrollment> results;
 
-    private Integer numberOfPrograms;
-
     public List<ProgramEnrollment> getResults() {
         return results;
     }
 
+    public ProgramEnrollment getFirstObject() { return results.get(0); }
+
     public Integer getNumberOfPrograms() {
-        return numberOfPrograms;
+        return results.size();
     }
 
     public void setResults(List<ProgramEnrollment> results) {
         this.results = results;
-    }
-
-    public void setNumberOfPrograms(Integer size) {
-        numberOfPrograms = size;
     }
 
     @Override

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
@@ -16,7 +16,7 @@ public class ProgramEnrollmentListResult {
 
     public ProgramEnrollment getFirstObject() { return results.get(0); }
 
-    public Integer getNumberOfPrograms() {
+    public int getNumberOfPrograms() {
         return results.size();
     }
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollmentListResult.java
@@ -14,15 +14,20 @@ public class ProgramEnrollmentListResult {
         return results;
     }
 
-    public ProgramEnrollment getFirstObject() { return results.get(0); }
+    public ProgramEnrollment getFirstObject() {
+
+        if (results.size() > 0) {
+            return results.get(0);
+        } else {
+            return null;
+        }
+    }
 
     public int getNumberOfPrograms() {
         return results.size();
     }
 
-    public void setResults(List<ProgramEnrollment> results) {
-        this.results = results;
-    }
+    public void setResults(List<ProgramEnrollment> results) { this.results = results; }
 
     @Override
     public int hashCode() {

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
@@ -45,7 +45,6 @@ import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PATIENT_MOTE
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PATIENT_UUID;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PERSON_UUID;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PROGRAM_ENROLLMENT;
-import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PROGRAM_ENROLLMENT_UUID;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PROGRAM_NAME;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.PROVIDER;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.RELATIONSHIP;
@@ -220,22 +219,21 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
             }
         }
 
-        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields, lookupFields.get(PROGRAM_NAME), lookupFields.get(ACTIVE_PROGRAM));
+        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields);
 
         return filteredProgramEnrollments;
     }
 
-    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields, String programName, String activeProgram) {
+    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields) {
         ProgramEnrollmentListResult result = new ProgramEnrollmentListResult();
-        String programEnrollmentUuid = lookupFields.get(PROGRAM_ENROLLMENT_UUID);
-        String personUuid = lookupFields.get(PERSON_UUID);
+        String programName = lookupFields.get(PROGRAM_NAME);
+        String patientUuid = lookupFields.get(PATIENT_UUID);
 
-        result.setResults(filterPrograms(programEnrollments, programName, activeProgram));
-        result.setNumberOfPrograms(result.getResults().size());
+        result.setResults(filterPrograms(programEnrollments, programName, lookupFields.get(ACTIVE_PROGRAM)));
 
         if (result.getNumberOfPrograms() > 1) {
-            LOGGER.warn(String.format("Multiple program enrollment found with the \"%s\" UUID and the person" +
-                    "with the \"%s\" UUID.", programEnrollmentUuid, personUuid));
+            LOGGER.warn(String.format("Multiple program enrollment found with the patient UUID \"%s\" and program name" +
+                    " \"%s\".", patientUuid, programName));
         }
         return result;
     }
@@ -247,13 +245,6 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
         programEnrollmentsList = filterByProgramName(programEnrollments, programName);
 
         result = isActiveProgram(activeProgram) ? filterByActiveProgramOnly(programEnrollmentsList) : programEnrollmentsList;
-
-        if (result.size() == 0) {
-            ProgramEnrollment programEnrollment  = new ProgramEnrollment();
-            programEnrollment.setEnrolled(false);
-
-            result.add(programEnrollment);
-        }
 
         return result;
     }

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
@@ -219,22 +219,33 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
             }
         }
 
-        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields);
+        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields, lookupName);
 
         return filteredProgramEnrollments;
     }
 
-    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields) {
+    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields, String lookupName) {
         ProgramEnrollmentListResult result = new ProgramEnrollmentListResult();
         String programName = lookupFields.get(PROGRAM_NAME);
-        String patientUuid = lookupFields.get(PATIENT_UUID);
 
         result.setResults(filterPrograms(programEnrollments, programName, lookupFields.get(ACTIVE_PROGRAM)));
 
         if (result.getNumberOfPrograms() > 1) {
-            LOGGER.warn(String.format("Multiple program enrollment found with the patient UUID \"%s\" and program name" +
-                    " \"%s\".", patientUuid, programName));
+            switch(lookupName) {
+                case BY_MOTECH_ID_AND_PROGRAM_NAME: {
+                    String motechId = lookupFields.get(PATIENT_MOTECH_ID);
+                    LOGGER.warn(String.format("Multiple program enrollment found with the patient MOTECH Id \"%s\" and program name" + " \"%s\".", motechId, programName));
+                    break;
+                }
+                case BY_UUID_AMD_PROGRAM_NAME: {
+                    String patientUuid = lookupFields.get(PATIENT_UUID);
+                    LOGGER.warn(String.format("Multiple program enrollment found with the patient UUID \"%s\" and program name" + " \"%s\".", patientUuid, programName));
+                    break;
+                }
+                default:
+            }
         }
+
         return result;
     }
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
@@ -139,8 +139,6 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
                     break;
                 case PROGRAM_ENROLLMENT:
                     obj = getProgramEnrollments(lookupName, lookupFields, configName);
-
-
             }
         }
 
@@ -254,10 +252,8 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
     }
 
     private List<ProgramEnrollment> filterPrograms(List<ProgramEnrollment> programEnrollments, String programName, String activeProgram) {
-        List<ProgramEnrollment> programEnrollmentsList;
+        List<ProgramEnrollment> programEnrollmentsList = filterByProgramName(programEnrollments, programName);
         List<ProgramEnrollment> result;
-
-        programEnrollmentsList = filterByProgramName(programEnrollments, programName);
 
         result = isActiveProgram(activeProgram) ? filterByActiveProgramOnly(programEnrollmentsList) : programEnrollmentsList;
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
@@ -219,18 +219,25 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
             }
         }
 
-        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields, lookupName);
+        ProgramEnrollmentListResult filteredProgramEnrollments = prepareProgramEnrollmentListResult(programEnrollments, lookupFields);
+        checkNumberOfPrograms(filteredProgramEnrollments, lookupFields, lookupName);
 
         return filteredProgramEnrollments;
     }
 
-    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields, String lookupName) {
+    private ProgramEnrollmentListResult prepareProgramEnrollmentListResult(List<ProgramEnrollment> programEnrollments, Map<String, String> lookupFields) {
         ProgramEnrollmentListResult result = new ProgramEnrollmentListResult();
         String programName = lookupFields.get(PROGRAM_NAME);
 
         result.setResults(filterPrograms(programEnrollments, programName, lookupFields.get(ACTIVE_PROGRAM)));
 
-        if (result.getNumberOfPrograms() > 1) {
+        return result;
+    }
+
+    private void checkNumberOfPrograms(ProgramEnrollmentListResult programEnrollmentListResult, Map<String, String> lookupFields, String lookupName) {
+        String programName = lookupFields.get(PROGRAM_NAME);
+
+        if (programEnrollmentListResult.getNumberOfPrograms() > 1) {
             switch(lookupName) {
                 case BY_MOTECH_ID_AND_PROGRAM_NAME: {
                     String motechId = lookupFields.get(PATIENT_MOTECH_ID);
@@ -242,11 +249,8 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
                     LOGGER.warn(String.format("Multiple program enrollment found with the patient UUID \"%s\" and program name" + " \"%s\".", patientUuid, programName));
                     break;
                 }
-                default:
             }
         }
-
-        return result;
     }
 
     private List<ProgramEnrollment> filterPrograms(List<ProgramEnrollment> programEnrollments, String programName, String activeProgram) {

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTasksConstants.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTasksConstants.java
@@ -29,6 +29,8 @@ public final class OpenMRSTasksConstants {
     public static final String PERSON_UUID = "openMRS.person.uuid";
     public static final String RELATIONSHIP_TYPE_UUID = "openMRS.relationshipType.uuid";
     public static final String PROGRAM_NAME = "openMRS.programName";
+    public static final String PROGRAM_ENROLLMENT_UUID = "openMRS.programEnrollment.uuid";
+    public static final String ACTIVE_PROGRAM = "openMRS.activeProgramOnly";
 
     private OpenMRSTasksConstants() {
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/constants/Keys.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/constants/Keys.java
@@ -11,12 +11,12 @@ public final class Keys {
     public static final String ENCOUNTER_DATE = "encounterDatetime";
     public static final String ENCOUNTER_TYPE = "encounterType";
     public static final String LOCATION_NAME = "locationName";
-    public static final String PATIENT_UUID = "patientUuid";
+    public static final String PATIENT_UUID = "patient.uuid";
     public static final String PROVIDER_UUID = "providerUuid";
     public static final String OBSERVATION = "observation";
 
     //Patient action
-    public static final String PERSON_UUID = "personUuid";
+    public static final String PERSON_UUID = "person.uuid";
     public static final String GIVEN_NAME = "givenName";
     public static final String MIDDLE_NAME = "middleName";
     public static final String FAMILY_NAME = "familyName";
@@ -45,7 +45,7 @@ public final class Keys {
     public static final String IDENTIFIERS = "identifiers";
 
     //Program Enrollment action
-    public static final String PROGRAM_UUID = "programUuid";
+    public static final String PROGRAM_UUID = "program.uuid";
     public static final String PROGRAM_ENROLLMENT_UUID = "programEnrollmentUuid";
     public static final String DATE_ENROLLED = "dateEnrolled";
     public static final String DATE_COMPLETED = "dateCompleted";

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -235,37 +235,33 @@
           "fields": [
             {
               "displayName": "openMRS.programEnrollment.uuid",
-              "fieldKey": "results.0.uuid"
+              "fieldKey": "firstObject.uuid"
             },
             {
               "displayName": "openMRS.patient.uuid",
-              "fieldKey": "results.0.patient.uuid"
+              "fieldKey": "firstObject.patient.uuid"
             },
             {
               "displayName": "openMRS.program.uuid",
-              "fieldKey": "results.0.program.uuid"
+              "fieldKey": "firstObject.program.uuid"
             },
             {
               "displayName": "openMRS.programEnrollment.dateEnrolled",
-              "fieldKey": "results.0.dateEnrolled",
+              "fieldKey": "firstObject.dateEnrolled",
               "type": "DATE"
             },
             {
               "displayName": "openMRS.programEnrollment.dateCompleted",
-              "fieldKey": "results.0.dateCompleted",
+              "fieldKey": "firstObject.dateCompleted",
               "type": "DATE"
             },
             {
               "displayName": "openMRS.location.name",
-              "fieldKey": "results.0.location.name"
-            },
-            {
-              "displayName": "openMRS.programEnrollment.enrolled",
-              "fieldKey": "results.0.enrolledString"
+              "fieldKey": "firstObject.location.name"
             },
             {
               "displayName": "openMRS.programEnrollment.currentState.uuid",
-              "fieldKey": "results.0.currentState.state.uuid"
+              "fieldKey": "firstObject.currentState.state.uuid"
             },
             {
               "displayName": "openMRS.programEnrollment.moreThanOneProgram",

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -219,51 +219,57 @@
               "displayName": "openMRS.lookup.motechIdAndProgramName",
               "fields": [
                 "openMRS.patient.motechId",
-                "openMRS.programName"
+                "openMRS.programName",
+                "openMRS.activeProgramOnly"
               ]
             },
             {
               "displayName": "openMRS.lookup.uuidAndProgramName",
               "fields": [
                 "openMRS.patient.uuid",
-                "openMRS.programName"
+                "openMRS.programName",
+                "openMRS.activeProgramOnly"
               ]
             }
           ],
           "fields": [
             {
               "displayName": "openMRS.programEnrollment.uuid",
-              "fieldKey": "uuid"
+              "fieldKey": "results.0.uuid"
             },
             {
               "displayName": "openMRS.patient.uuid",
-              "fieldKey": "patient.uuid"
+              "fieldKey": "results.0.patient.uuid"
             },
             {
               "displayName": "openMRS.program.uuid",
-              "fieldKey": "program.uuid"
+              "fieldKey": "results.0.program.uuid"
             },
             {
               "displayName": "openMRS.programEnrollment.dateEnrolled",
-              "fieldKey": "dateEnrolled",
+              "fieldKey": "results.0.dateEnrolled",
               "type": "DATE"
             },
             {
               "displayName": "openMRS.programEnrollment.dateCompleted",
-              "fieldKey": "dateCompleted",
+              "fieldKey": "results.0.dateCompleted",
               "type": "DATE"
             },
             {
               "displayName": "openMRS.location.name",
-              "fieldKey": "location.name"
+              "fieldKey": "results.0.location.name"
             },
             {
               "displayName": "openMRS.programEnrollment.enrolled",
-              "fieldKey": "enrolledString"
+              "fieldKey": "results.0.enrolledString"
             },
             {
               "displayName": "openMRS.programEnrollment.currentState.uuid",
-              "fieldKey": "currentState.state.uuid"
+              "fieldKey": "results.0.currentState.state.uuid"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.moreThanOneProgram",
+              "fieldKey": "numberOfPrograms"
             }
           ]
         }

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -264,7 +264,7 @@
               "fieldKey": "firstObject.currentState.state.uuid"
             },
             {
-              "displayName": "openMRS.programEnrollment.moreThanOneProgram",
+              "displayName": "openMRS.programEnrollment.numberOfPrograms",
               "fieldKey": "numberOfPrograms"
             }
           ]

--- a/openmrs/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs/src/main/resources/webapp/messages/messages.properties
@@ -34,6 +34,7 @@ openMRS.person=Person
 openMRS.motechId=MotechId
 openMRS.uuid=UUID
 openMRS.programName=Program name
+openMRS.activeProgramOnly=Active program only
 
 #Field names for OpenMRS model
 #Encounter
@@ -116,6 +117,7 @@ openMRS.programEnrollment.dateCompleted=Completed Date
 openMRS.programEnrollment.states=States
 openMRS.programEnrollment.enrolled=Enrolled
 openMRS.programEnrollment.currentState.uuid=Current State UUID
+openMRS.programEnrollment.moreThanOneProgram=No. program(s) returned
 
 #Configuration
 openMRS.config.settings=Settings

--- a/openmrs/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs/src/main/resources/webapp/messages/messages.properties
@@ -117,7 +117,7 @@ openMRS.programEnrollment.dateCompleted=Completed Date
 openMRS.programEnrollment.states=States
 openMRS.programEnrollment.enrolled=Enrolled
 openMRS.programEnrollment.currentState.uuid=Current State UUID
-openMRS.programEnrollment.moreThanOneProgram=No. program(s) returned
+openMRS.programEnrollment.numberOfPrograms=No. program(s) returned
 
 #Configuration
 openMRS.config.settings=Settings

--- a/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSTaskIntegrationBundle1_12IT.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSTaskIntegrationBundle1_12IT.java
@@ -169,8 +169,8 @@ public class MRSTaskIntegrationBundle1_12IT extends AbstractTaskBundleIT {
         taskConfig.addAll(taskConfigStepSortedSet);
 
         Map<String, String> values = new HashMap<>();
-        values.put(Keys.PATIENT_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.patient.uuid}}");
-        values.put(Keys.PROGRAM_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.program.uuid}}");
+        values.put(Keys.PATIENT_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.results.0.patient.uuid}}");
+        values.put(Keys.PROGRAM_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.results.0.program.uuid}}");
         values.put(Keys.DATE_ENROLLED, new DateTime("2010-01-16T00:00:00Z").toString());
         values.put(Keys.DATE_COMPLETED, new DateTime("2016-01-16T00:00:00Z").toString());
         values.put(Keys.LOCATION_NAME, locationService.getLocations(DEFAULT_CONFIG_NAME, DEFAULT_LOCATION_NAME).get(0).toString());

--- a/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSTaskIntegrationBundle1_12IT.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/it/version1_12/MRSTaskIntegrationBundle1_12IT.java
@@ -169,8 +169,8 @@ public class MRSTaskIntegrationBundle1_12IT extends AbstractTaskBundleIT {
         taskConfig.addAll(taskConfigStepSortedSet);
 
         Map<String, String> values = new HashMap<>();
-        values.put(Keys.PATIENT_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.results.0.patient.uuid}}");
-        values.put(Keys.PROGRAM_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.results.0.program.uuid}}");
+        values.put(Keys.PATIENT_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.firstObject.patient.uuid}}");
+        values.put(Keys.PROGRAM_UUID, "{{ad.openMRS.ProgramEnrollment-" + DEFAULT_CONFIG_NAME + "#0.firstObject.program.uuid}}");
         values.put(Keys.DATE_ENROLLED, new DateTime("2010-01-16T00:00:00Z").toString());
         values.put(Keys.DATE_COMPLETED, new DateTime("2016-01-16T00:00:00Z").toString());
         values.put(Keys.LOCATION_NAME, locationService.getLocations(DEFAULT_CONFIG_NAME, DEFAULT_LOCATION_NAME).get(0).toString());
@@ -290,6 +290,7 @@ public class MRSTaskIntegrationBundle1_12IT extends AbstractTaskBundleIT {
         List<Lookup> lookupList = new ArrayList<>();
         lookupList.add(new Lookup("openMRS.patient.motechId", MOTECH_ID));
         lookupList.add(new Lookup("openMRS.programName", createdProgramEnrollment.getProgram().getName()));
+        lookupList.add(new Lookup("openMRS.activeProgramOnly", "false"));
         DataSource dataSource = new DataSource(OPENMRS_MODULE_NAME, 4L, 0L, "ProgramEnrollment-" + DEFAULT_CONFIG_NAME, "openMRS.lookup.motechIdAndProgramName", lookupList, false);
         dataSource.setOrder(0);
         return dataSource;

--- a/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
@@ -365,7 +365,7 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertEquals(0, actual.getResults().size());
+        assertTrue(actual.getResults().isEmpty());
 
         verifyZeroInteractions(programEnrollmentService);
     }
@@ -468,7 +468,7 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertEquals(0, actual.getResults().size());
+        assertTrue(actual.getResults().isEmpty());
     }
 
     @Test
@@ -490,7 +490,7 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertEquals(0, actual.getResults().size());
+        assertTrue(actual.getResults().isEmpty());
     }
 
     private List<Relationship> prepareRelationship() {

--- a/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
@@ -352,7 +352,7 @@ public class OpenMRSTaskDataProviderTest {
     }
 
     @Test
-    public void shouldReturnNotEnrolledWhenWrongLookupNameForProgramEnrollment() {
+    public void shouldReturnEmptyListWhenWrongLookupNameForProgramEnrollment() {
         String className = ProgramEnrollment.class.getSimpleName();
 
         Map<String, String> lookupFields = new HashMap<>();
@@ -365,9 +365,7 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertFalse(actual.getResults().get(0).isEnrolled());
-        assertEquals(ProgramEnrollment.NOT_ENROLLED, actual.getResults().get(0).getEnrolledString());
-        assertNull(actual.getResults().get(0).getCurrentState());
+        assertEquals(0, actual.getResults().size());
 
         verifyZeroInteractions(programEnrollmentService);
     }
@@ -452,7 +450,7 @@ public class OpenMRSTaskDataProviderTest {
     }
 
     @Test
-    public void shouldReturnNotEnrolledWhenProgramEnrollmentNotFoundForLookupByUuidAndProgramName() {
+    public void shouldReturnEmptyListWhenProgramEnrollmentNotFoundForLookupByUuidAndProgramName() {
         String className = ProgramEnrollment.class.getSimpleName();
 
         Map<String, String> lookupFields = new HashMap<>();
@@ -470,13 +468,11 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertFalse(actual.getResults().get(0).isEnrolled());
-        assertEquals(ProgramEnrollment.NOT_ENROLLED, actual.getResults().get(0).getEnrolledString());
-        assertNull(actual.getResults().get(0).getCurrentState());
+        assertEquals(0, actual.getResults().size());
     }
 
     @Test
-    public void shouldReturnNotEnrolledWhenProgramEnrollmentNotFoundForLookupByMotechIdAndProgramName() {
+    public void shouldReturnEmptyListWhenProgramEnrollmentNotFoundForLookupByMotechIdAndProgramName() {
         String className = ProgramEnrollment.class.getSimpleName();
 
         Map<String, String> lookupFields = new HashMap<>();
@@ -494,9 +490,7 @@ public class OpenMRSTaskDataProviderTest {
 
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
-        assertFalse(actual.getResults().get(0).isEnrolled());
-        assertEquals(ProgramEnrollment.NOT_ENROLLED, actual.getResults().get(0).getEnrolledString());
-        assertNull(actual.getResults().get(0).getCurrentState());
+        assertEquals(0, actual.getResults().size());
     }
 
     private List<Relationship> prepareRelationship() {

--- a/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderTest.java
@@ -366,6 +366,7 @@ public class OpenMRSTaskDataProviderTest {
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
         assertTrue(actual.getResults().isEmpty());
+        assertEquals(0, actual.getNumberOfPrograms());
 
         verifyZeroInteractions(programEnrollmentService);
     }
@@ -400,7 +401,7 @@ public class OpenMRSTaskDataProviderTest {
     @Test
     public void shouldReturnOnlyActiveProgramEnrollmentForPatientUuidAndProgramName() {
         String className = ProgramEnrollment.class.getSimpleName();
-        Integer expectedNumberOfPrograms = 1;
+
         Map<String, String> lookupFields = new HashMap<>();
         lookupFields.put(PATIENT_UUID, DEFAULT_UUID);
         lookupFields.put(PROGRAM_NAME, PROGRAM_DEFAULT_NAME);
@@ -420,7 +421,7 @@ public class OpenMRSTaskDataProviderTest {
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
         assertEquals(expected.get(0), actual.getResults().get(0));
-        assertEquals(expectedNumberOfPrograms, actual.getNumberOfPrograms());
+        assertEquals(1, actual.getNumberOfPrograms());
     }
 
     @Test
@@ -469,6 +470,7 @@ public class OpenMRSTaskDataProviderTest {
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
         assertTrue(actual.getResults().isEmpty());
+        assertEquals(0, actual.getNumberOfPrograms());
     }
 
     @Test
@@ -491,6 +493,7 @@ public class OpenMRSTaskDataProviderTest {
         ProgramEnrollmentListResult actual = (ProgramEnrollmentListResult) object;
 
         assertTrue(actual.getResults().isEmpty());
+        assertEquals(0, actual.getNumberOfPrograms());
     }
 
     private List<Relationship> prepareRelationship() {


### PR DESCRIPTION
- I added possibility to get only active programs from Program Enrollment task data source. It is "Active Program Only" lookup field which should be to set on true or false. 
- Program enrollment data source returns "No. program(s) returned" bubble, now. It contains number of programs from data source.
