### PR TITLE
MOTECH-2761: Add person attributes to OpenMRS 'get patient' task data source

### DIFF
--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/Attribute.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/Attribute.java
@@ -72,8 +72,8 @@ public class Attribute {
             return display;
         }
 
-        public void setDisplay() {
-
+        public void setDisplay(String display) {
+            this.display = display;
         }
 
         public String getUuid() {

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/Attribute.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/Attribute.java
@@ -64,7 +64,17 @@ public class Attribute {
      */
     public static class AttributeType {
 
+        private String display;
+
         private String uuid;
+
+        public String getDisplay() {
+            return display;
+        }
+
+        public void setDisplay() {
+
+        }
 
         public String getUuid() {
             return uuid;

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/Person.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/Person.java
@@ -597,7 +597,7 @@ public class Person {
         this.auditInfo = auditInfo;
     }
 
-    public Map<String, String> getAttributesMap() {
+    public Map<String, String> getPersonAttributes() {
         Map<String, String> personAttributes = new HashMap<>();
         for (Attribute attribute : attributes) {
             personAttributes.put(attribute.getAttributeType().getDisplay(), attribute.getValue());

--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/Person.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/Person.java
@@ -11,7 +11,9 @@ import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -593,6 +595,14 @@ public class Person {
 
     public void setAuditInfo(AuditInfo auditInfo) {
         this.auditInfo = auditInfo;
+    }
+
+    public Map<String, String> getAttributesMap() {
+        Map<String, String> personAttributes = new HashMap<>();
+        for (Attribute attribute : attributes) {
+            personAttributes.put(attribute.getAttributeType().getDisplay(), attribute.getValue());
+        }
+        return personAttributes;
     }
 
     @Override

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -85,6 +85,11 @@
               "type": "MAP"
             },
             {
+              "displayName": "openMRS.patient.personAttributes",
+              "fieldKey": "person.attributesMap",
+              "type": "MAP"
+            },
+            {
               "displayName": "openMRS.motechId",
               "fieldKey": "motechId"
             },

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -86,7 +86,7 @@
             },
             {
               "displayName": "openMRS.patient.personAttributes",
-              "fieldKey": "person.attributesMap",
+              "fieldKey": "person.personAttributes",
               "type": "MAP"
             },
             {

--- a/openmrs/src/main/resources/webapp/messages/messages.properties
+++ b/openmrs/src/main/resources/webapp/messages/messages.properties
@@ -53,6 +53,7 @@ openMRS.patient.display=Patient display
 openMRS.patient.uuid=Patient UUID
 openMRS.patient.motechId=Patient MOTECH ID
 openMRS.patient.identifiers=Patient identifiers
+openMRS.patient.personAttributes=Patient attributes
 
 #Person
 openMRS.person.age=Person age

--- a/openmrs/src/test/java/org/motechproject/openmrs/it/MRSTasksIntegrationBundleIT.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/it/MRSTasksIntegrationBundleIT.java
@@ -10,6 +10,7 @@ import org.motechproject.config.domain.SettingsRecord;
 import org.motechproject.config.mds.SettingsDataService;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.util.Order;
+import org.motechproject.openmrs.domain.Attribute;
 import org.motechproject.openmrs.domain.Encounter;
 import org.motechproject.openmrs.domain.EncounterType;
 import org.motechproject.openmrs.domain.Location;
@@ -173,6 +174,8 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
 
     @Test
     public void testOpenMRSPatientDataSourceAndCreatePatientAction() throws InterruptedException, IOException, PatientNotFoundException {
+        updatePatient();
+
         Long taskID = createPatientTestTask();
 
         activateTrigger();
@@ -224,6 +227,7 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
         Map<String, String> values = new HashMap<>();
         values.put(Keys.ADDRESS_1, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.person.birthdate}}");
         values.put(Keys.ADDRESS_2, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.uuid}}");
+        values.put(Keys.ADDRESS_3, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.person.personAttributes.Birthplace}}");
         values.put(Keys.FAMILY_NAME, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.person.display}}");
         values.put(Keys.GENDER, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.person.gender}}");
         values.put(Keys.GIVEN_NAME, "{{ad.openMRS.Patient-" + DEFAULT_CONFIG_NAME + "#0.person.display}}");
@@ -341,6 +345,16 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
         return new Patient(person, MOTECH_ID, location);
     }
 
+    private void updatePatient() {
+        Attribute.AttributeType attributeType = new Attribute.AttributeType();
+        attributeType.setUuid("8d8718c2-c2cc-11de-8d13-0010c6dffd0f");
+        Attribute personAttribute = new Attribute();
+        personAttribute.setAttributeType(attributeType);
+        personAttribute.setValue("New York");
+        createdPatient.getPerson().getAttributes().add(personAttribute);
+        patientService.updatePatient(DEFAULT_CONFIG_NAME, createdPatient);
+    }
+
     private Provider prepareProvider() {
 
         Person person = new Person();
@@ -424,6 +438,7 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
 
         assertEquals(createdPatient.getUuid(), patient.getPerson().getPreferredAddress().getAddress2());
         assertEquals(createdPatient.getPerson().getBirthdate().toString(), patient.getPerson().getPreferredAddress().getAddress1());
+        assertEquals(createdPatient.getPerson().getAttributes().get(0).getValue(), patient.getPerson().getPreferredAddress().getAddress3());
         assertEquals(String.format("%staskCreated", MOTECH_ID), patient.getMotechId());
         assertEquals(createdPatient.getPerson().getGender(), patient.getPerson().getGender());
 

--- a/openmrs/src/test/java/org/motechproject/openmrs/it/MRSTasksIntegrationBundleIT.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/it/MRSTasksIntegrationBundleIT.java
@@ -174,7 +174,7 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
 
     @Test
     public void testOpenMRSPatientDataSourceAndCreatePatientAction() throws InterruptedException, IOException, PatientNotFoundException {
-        updatePatient();
+        updatePatientWithNewAttribute();
 
         Long taskID = createPatientTestTask();
 
@@ -345,13 +345,17 @@ public class MRSTasksIntegrationBundleIT extends AbstractTaskBundleIT {
         return new Patient(person, MOTECH_ID, location);
     }
 
-    private void updatePatient() {
+    private void updatePatientWithNewAttribute() {
+
         Attribute.AttributeType attributeType = new Attribute.AttributeType();
-        attributeType.setUuid("8d8718c2-c2cc-11de-8d13-0010c6dffd0f");
+        attributeType.setUuid("8d8718c2-c2cc-11de-8d13-0010c6dffd0f"); // this UUID indicates BirthPlace person Attribute on OpenMRS server
+
         Attribute personAttribute = new Attribute();
         personAttribute.setAttributeType(attributeType);
         personAttribute.setValue("New York");
+
         createdPatient.getPerson().getAttributes().add(personAttribute);
+
         patientService.updatePatient(DEFAULT_CONFIG_NAME, createdPatient);
     }
 


### PR DESCRIPTION
To access person attributes in patient data source you need to use notation like this: `ad.OpenMRS.Patient-configName#0.peron.personAttribute.attributeDisplayName`, where "attributeDisplayName" will be for example givenNameLocal, like in description of [MOTECH-2761](https://applab.atlassian.net/browse/MOTECH-2761) but with "person" prefix
