### PR TITLE
MOTECH-2776: error message handle and parse to json

### DIFF
--- a/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
+++ b/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
@@ -1,5 +1,7 @@
 package org.motechproject.commcare.web;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.motechproject.commcare.exception.CommcareAuthenticationException;
 import org.motechproject.commcare.exception.CommcareConnectionFailureException;
 import org.motechproject.commcare.exception.ConfigurationNotFoundException;
@@ -56,7 +58,12 @@ public abstract class CommcareController {
 
     private String handleException(Exception e) {
         logger.error(e.getMessage(), e);
-        return e.getMessage();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("message", e.getMessage());
+
+        Gson gson = new Gson();
+        return gson.toJson(jsonObject);
     }
 
 }

--- a/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
+++ b/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
@@ -1,11 +1,10 @@
 package org.motechproject.commcare.web;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import org.motechproject.commcare.exception.CommcareAuthenticationException;
 import org.motechproject.commcare.exception.CommcareConnectionFailureException;
 import org.motechproject.commcare.exception.ConfigurationNotFoundException;
 import org.motechproject.commcare.exception.EndpointNotSupported;
+import org.motechproject.commons.api.json.MotechMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -24,46 +23,36 @@ public abstract class CommcareController {
     @ExceptionHandler({ConfigurationNotFoundException.class, CommcareConnectionFailureException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ResponseBody
-    public String handleNotFound(Exception e) {
-        return handleException(e);
+    public MotechMessage handleNotFound(Exception e) {
+        return new MotechMessage(e.getMessage());
     }
 
     @ExceptionHandler(EndpointNotSupported.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
-    public String handleBadRequest(Exception e) {
-        return handleException(e);
+    public MotechMessage handleBadRequest(Exception e) {
+        return new MotechMessage(e.getMessage());
     }
 
     @ExceptionHandler(CommcareAuthenticationException.class)
     @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
     @ResponseBody
-    public String handleCommcareAuthenticationException(CommcareAuthenticationException e) {
-        return handleException(e);
+    public MotechMessage handleCommcareAuthenticationException(CommcareAuthenticationException e) {
+        return new MotechMessage(e.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(value = HttpStatus.CONFLICT)
     @ResponseBody
-    public String handleIllegalArgumentException(IllegalArgumentException e) {
-        return handleException(e);
+    public MotechMessage handleIllegalArgumentException(IllegalArgumentException e) {
+        return new MotechMessage(e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
-    public String handleMiscException(Exception e) {
-        return handleException(e);
-    }
-
-    private String handleException(Exception e) {
-        logger.error(e.getMessage(), e);
-
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty("message", e.getMessage());
-
-        Gson gson = new Gson();
-        return gson.toJson(jsonObject);
+    public MotechMessage handleMiscException(Exception e) {
+        return new MotechMessage(e.getMessage());
     }
 
 }

--- a/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
+++ b/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
@@ -24,35 +24,38 @@ public abstract class CommcareController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ResponseBody
     public MotechMessage handleNotFound(Exception e) {
-        return new MotechMessage(e.getMessage());
+        return handleException(e);
     }
 
     @ExceptionHandler(EndpointNotSupported.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
     public MotechMessage handleBadRequest(Exception e) {
-        return new MotechMessage(e.getMessage());
+        return handleException(e);
     }
 
     @ExceptionHandler(CommcareAuthenticationException.class)
     @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
     @ResponseBody
     public MotechMessage handleCommcareAuthenticationException(CommcareAuthenticationException e) {
-        return new MotechMessage(e.getMessage());
+        return handleException(e);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(value = HttpStatus.CONFLICT)
     @ResponseBody
     public MotechMessage handleIllegalArgumentException(IllegalArgumentException e) {
-        return new MotechMessage(e.getMessage());
+        return handleException(e);
     }
 
     @ExceptionHandler(Exception.class)
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
     public MotechMessage handleMiscException(Exception e) {
-        return new MotechMessage(e.getMessage());
+        return handleException(e);
     }
 
+    private MotechMessage handleException(Exception e) {
+        return handleException(e);
+    }
 }

--- a/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
+++ b/commcare/src/main/java/org/motechproject/commcare/web/CommcareController.java
@@ -56,6 +56,7 @@ public abstract class CommcareController {
     }
 
     private MotechMessage handleException(Exception e) {
-        return handleException(e);
+        logger.error(e.getMessage(), e);
+        return new MotechMessage(e.getMessage());
     }
 }

--- a/commcare/src/main/resources/webapp/js/controllers.js
+++ b/commcare/src/main/resources/webapp/js/controllers.js
@@ -396,7 +396,7 @@
                     LoadingModal.close();
                 },
                 function failure(response) {
-                    $scope.syncErrorMessage = response.data;
+                    $scope.syncErrorMessage = response.data.message;
                     $scope.syncSuccess = false;
                     $scope.syncedConfig = $scope.selectedConfig.name;
                     LoadingModal.close();
@@ -546,7 +546,7 @@
                 },
                 function failure(response) {
                     $scope.verifySuccessMessage = '';
-                    $scope.verifyErrorMessage =  response.data;
+                    $scope.verifyErrorMessage =  response.data.message;
                     $scope.connectionVerified = false;
                     LoadingModal.close();
                 });
@@ -571,7 +571,7 @@
                 },
                 function failure(response) {
                     $scope.verifySuccessMessage = '';
-                    $scope.verifyErrorMessage =  response.data;
+                    $scope.verifyErrorMessage =  response.data.message;
                     $scope.connectionVerified = false;
                     LoadingModal.close();
                 });

--- a/commcare/src/main/resources/webapp/js/controllers.js
+++ b/commcare/src/main/resources/webapp/js/controllers.js
@@ -428,7 +428,7 @@
                     LoadingModal.close();
                 },
                 function failure(response) {
-                    $scope.verifyErrorMessage = response.data;
+                    $scope.verifyErrorMessage = response.data.message;
                     $scope.verifySuccessMessage = '';
                     $scope.connectionVerified = false;
                     LoadingModal.close();


### PR DESCRIPTION
There was empty error message if you add a configuration to CommCare with an incorrect password. Now the returned http response is valid json.
