### PR TITLE
Fixed constant key value

### DIFF
--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/constants/Keys.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/constants/Keys.java
@@ -11,7 +11,7 @@ public final class Keys {
     public static final String ENCOUNTER_DATE = "encounterDatetime";
     public static final String ENCOUNTER_TYPE = "encounterType";
     public static final String LOCATION_NAME = "locationName";
-    public static final String PATIENT_UUID = "patient.uuid";
+    public static final String PATIENT_UUID = "patientUuid";
     public static final String PROVIDER_UUID = "providerUuid";
     public static final String OBSERVATION = "observation";
 


### PR DESCRIPTION
Keys constants should not contain dots in value. This will cause error i.e. while trying to get the value of trigger's bubble with such key.
