### PR TITLE
MOTECH-2798: Added Bahmni Programe Enrollment data source lookup

### DIFF
--- a/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollment.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/domain/ProgramEnrollment.java
@@ -4,7 +4,9 @@ import com.google.gson.annotations.Expose;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -181,6 +183,14 @@ public class ProgramEnrollment {
 
     public void setEnrolled(boolean enrolled) {
         this.enrolled = enrolled;
+    }
+
+    public Map<String, String> getProgramAttributes() {
+        Map<String, String> programAttributes = new HashMap<>();
+        for (Attribute attribute : attributes) {
+            programAttributes.put(attribute.getAttributeType().getDisplay(), attribute.getValue());
+        }
+        return programAttributes;
     }
 
     public StateStatus getCurrentState() {

--- a/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/resource/impl/ProgramEnrollmentResourceImpl.java
@@ -16,7 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestOperations;
 
+import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class ProgramEnrollmentResourceImpl extends BaseResource implements ProgramEnrollmentResource {
@@ -69,7 +72,9 @@ public class ProgramEnrollmentResourceImpl extends BaseResource implements Progr
     @Override
     public List<ProgramEnrollment> getBahmniProgramEnrollmentByPatientUuid(Config config, String patientUuid) {
         String responseJson = getJson(config, "/bahmniprogramenrollment?patient={uuid}&v=full", patientUuid);
-        ProgramEnrollmentListResult programEnrollmentListResult = (ProgramEnrollmentListResult) JsonUtils.readJson(responseJson, ProgramEnrollmentListResult.class);
+        Map<Type, Object> attributeAdapter = new HashMap<Type, Object>();
+        attributeAdapter.put(Attribute.class, new Attribute.AttributeSerializer());
+        ProgramEnrollmentListResult programEnrollmentListResult = (ProgramEnrollmentListResult) JsonUtils.readJsonWithAdapters(responseJson, ProgramEnrollmentListResult.class, attributeAdapter);
         return programEnrollmentListResult.getResults();
     }
 

--- a/openmrs/src/main/java/org/motechproject/openmrs/service/OpenMRSProgramEnrollmentService.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/service/OpenMRSProgramEnrollmentService.java
@@ -30,6 +30,26 @@ public interface OpenMRSProgramEnrollmentService {
     ProgramEnrollment updateProgramEnrollment(String configName, ProgramEnrollment programEnrollment);
 
     /**
+     * Returns Bahmni program enrollments associated with the patient having given UUID.
+     * Configuration with the given {@code configName} will be used while performing this action.
+     *
+     * @param configName the name of the configuration
+     * @param patientUuid the UUID of the patient
+     * @return list of matching Bahmni program enrollments
+     */
+    List<ProgramEnrollment> getBahmniProgramEnrollmentByPatientUuid(String configName, String patientUuid);
+
+    /**
+     * Returns Bahmni program enrollments associated with the patient having given MOTECH ID.
+     * Configuration with the given {@code configName} will be used while performing this action.
+     *
+     * @param configName the name of the configuration
+     * @param patientMotechId the MOTECH ID of the patient
+     * @return list of matching Bahmni program enrollments
+     */
+    List<ProgramEnrollment> getBahmniProgramEnrollmentByPatientMotechId(String configName, String patientMotechId);
+
+    /**
      * Returns program enrollments associated with the patient having given UUID.
      * Configuration with the given {@code configName} will be used while performing this action.
      *

--- a/openmrs/src/main/java/org/motechproject/openmrs/service/impl/OpenMRSProgramEnrollmentServiceImpl.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/service/impl/OpenMRSProgramEnrollmentServiceImpl.java
@@ -84,6 +84,18 @@ public class OpenMRSProgramEnrollmentServiceImpl implements OpenMRSProgramEnroll
     }
 
     @Override
+    public List<ProgramEnrollment> getBahmniProgramEnrollmentByPatientUuid(String configName, String patientUuid)  {
+        return programEnrollmentResource.getBahmniProgramEnrollmentByPatientUuid(configService.getConfigByName(configName), patientUuid);
+    }
+
+    @Override
+    public List<ProgramEnrollment> getBahmniProgramEnrollmentByPatientMotechId(String configName, String patientMotechId) {
+        Patient patient = patientService.getPatientByMotechId(configName, patientMotechId);
+
+        return Objects.nonNull(patient) ? getBahmniProgramEnrollmentByPatientUuid(configName, patient.getUuid()) : new ArrayList<>();
+    }
+
+    @Override
     public List<ProgramEnrollment> getProgramEnrollmentByPatientUuid(String configName, String patientUuid) {
         return programEnrollmentResource.getProgramEnrollmentByPatientUuid(configService.getConfigByName(configName), patientUuid);
     }

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProvider.java
@@ -37,6 +37,7 @@ import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.ACTIVE_PROGR
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.BY_MOTECH_ID;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.BY_MOTECH_ID_AND_PROGRAM_NAME;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.BY_UUID;
+import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.BAHMNI_PROGRAM_ENROLLMENT;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.BY_UUID_AMD_PROGRAM_NAME;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.ENCOUNTER;
 import static org.motechproject.openmrs.tasks.OpenMRSTasksConstants.IDENTIFIER;
@@ -132,6 +133,12 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
 
         String objectType = type.substring(0, type.lastIndexOf('-'));
         String configName = type.substring(type.lastIndexOf('-') + 1);
+        boolean isBahmniProgramEnrollment = false;
+
+        if (StringUtils.equals(BAHMNI_PROGRAM_ENROLLMENT, objectType)) {
+            isBahmniProgramEnrollment = true;
+            objectType = PROGRAM_ENROLLMENT;
+        }
 
         //In case of any trouble with the type, 'supports' method logs an error
         if (supports(objectType)) {
@@ -144,7 +151,7 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
                     break;
                 case RELATIONSHIP: obj = getRelationship(lookupFields, configName);
                     break;
-                case PROGRAM_ENROLLMENT: obj = getProgramEnrollments(lookupName, lookupFields, configName);
+                case PROGRAM_ENROLLMENT: obj = getProgramEnrollments(lookupName, lookupFields, configName, isBahmniProgramEnrollment);
                     break;
                 case IDENTIFIER: obj = getIdentifier(lookupFields, configName);
             }
@@ -207,16 +214,24 @@ public class OpenMRSTaskDataProvider extends AbstractDataProvider {
         return relationships.isEmpty() ? null : relationships.get(0);
     }
 
-    private ProgramEnrollmentListResult getProgramEnrollments(String lookupName, Map<String, String> lookupFields, String configName) {
+    private ProgramEnrollmentListResult getProgramEnrollments(String lookupName, Map<String, String> lookupFields, String configName, boolean isBahmniProgramEnrollment) {
         List<ProgramEnrollment> programEnrollments = null;
 
         switch (lookupName) {
             case BY_MOTECH_ID_AND_PROGRAM_NAME: {
-                programEnrollments = programEnrollmentService.getProgramEnrollmentByPatientMotechId(configName, lookupFields.get(PATIENT_MOTECH_ID));
+                if (isBahmniProgramEnrollment) {
+                    programEnrollments = programEnrollmentService.getBahmniProgramEnrollmentByPatientMotechId(configName, lookupFields.get(PATIENT_MOTECH_ID));
+                } else {
+                    programEnrollments = programEnrollmentService.getProgramEnrollmentByPatientMotechId(configName, lookupFields.get(PATIENT_MOTECH_ID));
+                }
                 break;
             }
             case BY_UUID_AMD_PROGRAM_NAME: {
-                programEnrollments = programEnrollmentService.getProgramEnrollmentByPatientUuid(configName, lookupFields.get(PATIENT_UUID));
+                if (isBahmniProgramEnrollment) {
+                    programEnrollments = programEnrollmentService.getBahmniProgramEnrollmentByPatientUuid(configName, lookupFields.get(PATIENT_UUID));
+                } else {
+                    programEnrollments = programEnrollmentService.getProgramEnrollmentByPatientUuid(configName, lookupFields.get(PATIENT_UUID));
+                }
                 break;
             }
             default: {

--- a/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTasksConstants.java
+++ b/openmrs/src/main/java/org/motechproject/openmrs/tasks/OpenMRSTasksConstants.java
@@ -20,6 +20,7 @@ public final class OpenMRSTasksConstants {
     public static final String PROVIDER = "Provider";
     public static final String RELATIONSHIP = "Relationship";
     public static final String PROGRAM_ENROLLMENT = "ProgramEnrollment";
+    public static final String BAHMNI_PROGRAM_ENROLLMENT = "BahmniProgramEnrollment";
     public static final String IDENTIFIER = "GeneratedIdentifier";
 
     // Field names

--- a/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
+++ b/openmrs/src/main/resources/velocity.templates/task-data-provider.vm
@@ -235,6 +235,69 @@
         }
         #if( "1.9" != $config.getOpenMrsVersion() ),
         {
+          "displayName": "Bahmni Program Enrollment [$config.getName()]",
+          "type": "BahmniProgramEnrollment-$config.getName()",
+          "lookupFields": [
+            {
+              "displayName": "openMRS.lookup.motechIdAndProgramName",
+              "fields": [
+                "openMRS.patient.motechId",
+                "openMRS.programName",
+                "openMRS.activeProgramOnly"
+              ]
+            },
+            {
+              "displayName": "openMRS.lookup.uuidAndProgramName",
+              "fields": [
+                "openMRS.patient.uuid",
+                "openMRS.programName",
+                "openMRS.activeProgramOnly"
+              ]
+            }
+          ],
+          "fields": [
+            {
+              "displayName": "openMRS.programEnrollment.uuid",
+              "fieldKey": "firstObject.uuid"
+            },
+            {
+              "displayName": "openMRS.patient.uuid",
+              "fieldKey": "firstObject.patient.uuid"
+            },
+            {
+              "displayName": "openMRS.program.uuid",
+              "fieldKey": "firstObject.program.uuid"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.dateEnrolled",
+              "fieldKey": "firstObject.dateEnrolled",
+              "type": "DATE"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.dateCompleted",
+              "fieldKey": "firstObject.dateCompleted",
+              "type": "DATE"
+            },
+            {
+              "displayName": "openMRS.location.name",
+              "fieldKey": "firstObject.location.name"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.currentState.uuid",
+              "fieldKey": "firstObject.currentState.state.uuid"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.numberOfPrograms",
+              "fieldKey": "numberOfPrograms"
+            },
+            {
+              "displayName": "openMRS.programEnrollment.attributes",
+              "fieldKey": "firstObject.programAttributes",
+              "type": "MAP"
+            }
+          ]
+        },
+        {
           "displayName": "Program Enrollment [$config.getName()]",
           "type": "ProgramEnrollment-$config.getName()",
           "lookupFields": [

--- a/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderBuilderTest.java
+++ b/openmrs/src/test/java/org/motechproject/openmrs/tasks/OpenMRSTaskDataProviderBuilderTest.java
@@ -48,12 +48,12 @@ public class OpenMRSTaskDataProviderBuilderTest {
 
     @Test
     public void generatedProviderShouldReturnJSONForOneConfiguration() throws IOException {
-        assertEquals(6, getGeneratedJSONObjectsCount(1));
+        assertEquals(7, getGeneratedJSONObjectsCount(1));
     }
 
     @Test
     public void generatedProviderShouldReturnJSONForTwoConfigurations() throws IOException {
-        assertEquals(12, getGeneratedJSONObjectsCount(2));
+        assertEquals(14, getGeneratedJSONObjectsCount(2));
     }
 
     private int getGeneratedJSONObjectsCount(int amountOfConfigs) throws IOException {


### PR DESCRIPTION
Added task data source which return Bahmni Program Enrollment with optional attributes.
Lookup can be done by "MOTECH ID and program name" as well as "UUID and program name".
Each program attribute is available by using handlebar notation.

Example:
`{{ad.openMRS.BahmniProgramEnrollment-openmrsbahmni#0.firstObject.programAttributes.attributeName}}`, where 'attributeName' is the display name of the attributeType. This would return the string value of the attribute which would contain either a text value like "test" or an uuid of the complex value object.

Fixed test which counts the number of data source lookups as it contains an additional one now.
