### PR TITLE
MOTECH-2972 Rename "Form" tab to "Form Definitions"

### DIFF
--- a/commcare/src/main/resources/webapp/messages/messages.properties
+++ b/commcare/src/main/resources/webapp/messages/messages.properties
@@ -3,7 +3,7 @@ commcare.ok=OK
 commcare.tab.dataMapping=Data Mapping
 commcare.tab.import=Import Forms
 commcare.tab.settings=Settings
-commcare.tab.forms=Forms
+commcare.tab.forms=Form Definitions
 commcare.tab.cases=Cases
 
 commcare.settings.section.accountSettings=Account Settings


### PR DESCRIPTION
Changed the name in from Forms to Form Definitions.
