### PR TITLE
Unsecured cms-lite module endpoints for retrieving stream and string contents

### DIFF
--- a/cms-lite/src/main/java/org/motechproject/cmslite/web/ResourceController.java
+++ b/cms-lite/src/main/java/org/motechproject/cmslite/web/ResourceController.java
@@ -43,7 +43,6 @@ import static org.apache.commons.lang.StringUtils.startsWithIgnoreCase;
  * Handles both the grid in the cms-lite UI and REST requests for particular resources.
  */
 @Controller
-@PreAuthorize("hasRole('manageCMS')")
 public class ResourceController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceController.class);
@@ -60,6 +59,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/available/{field}", method = RequestMethod.GET)
     @ResponseBody
+    @PreAuthorize("hasRole('manageCMS')")
     public Set<String> autocompleteField(@PathVariable String field, @RequestParam String term) throws CMSLiteException {
         Set<String> strings = new TreeSet<>();
 
@@ -95,6 +95,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource", method = RequestMethod.GET)
     @ResponseBody
+    @PreAuthorize("hasRole('manageCMS')")
     public Resources getContents(GridSettings settings) {
         List<Content> contents = cmsLiteService.getAllContents();
         List<ResourceDto> resourceDtos = ResourceFilter.filter(settings, contents);
@@ -110,6 +111,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/all/languages", method = RequestMethod.GET)
     @ResponseBody
+    @PreAuthorize("hasRole('manageCMS')")
     public Set<String> getAllLanguages() {
         List<Content> contents = cmsLiteService.getAllContents();
         Set<String> strings = new TreeSet<>();
@@ -132,6 +134,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/{type}/{language}/{name}", method = RequestMethod.GET)
     @ResponseBody
+    @PreAuthorize("hasRole('manageCMS')")
     public Content getContent(@PathVariable String type, @PathVariable String language, @PathVariable String name) throws ContentNotFoundException, CMSLiteException {
         Content content;
 
@@ -158,6 +161,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/string/{language}/{name}", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('manageCMS')")
     public void editStringContent(@PathVariable String language, @PathVariable String name,
                                   @RequestParam String value) throws ContentNotFoundException {
         StringContent stringContent = cmsLiteService.getStringContent(language, name);
@@ -176,6 +180,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/stream/{language}/{name}", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('manageCMS')")
     public void editStreamContent(@PathVariable String language, @PathVariable String name,
                                   @RequestParam MultipartFile file) throws ContentNotFoundException, IOException {
         StreamContent streamContent = cmsLiteService.getStreamContent(language, name);
@@ -199,6 +204,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('manageCMS')")
     public void addContent(@RequestParam String type,
                            @RequestParam String name,
                            @RequestParam String language,
@@ -257,6 +263,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/{type}/{language}/{name}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('manageCMS')")
     public void removeContent(@PathVariable String type, @PathVariable String language, @PathVariable String name) throws ContentNotFoundException, CMSLiteException {
         switch (type) {
             case "stream":

--- a/cms-lite/src/main/java/org/motechproject/cmslite/web/ResourceController.java
+++ b/cms-lite/src/main/java/org/motechproject/cmslite/web/ResourceController.java
@@ -47,6 +47,8 @@ public class ResourceController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceController.class);
 
+    private static final String CMS_ROLE = "hasRole('manageCMS')";
+
     @Autowired
     private CMSLiteService cmsLiteService;
 
@@ -59,7 +61,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/available/{field}", method = RequestMethod.GET)
     @ResponseBody
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public Set<String> autocompleteField(@PathVariable String field, @RequestParam String term) throws CMSLiteException {
         Set<String> strings = new TreeSet<>();
 
@@ -95,7 +97,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource", method = RequestMethod.GET)
     @ResponseBody
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public Resources getContents(GridSettings settings) {
         List<Content> contents = cmsLiteService.getAllContents();
         List<ResourceDto> resourceDtos = ResourceFilter.filter(settings, contents);
@@ -111,7 +113,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/all/languages", method = RequestMethod.GET)
     @ResponseBody
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public Set<String> getAllLanguages() {
         List<Content> contents = cmsLiteService.getAllContents();
         Set<String> strings = new TreeSet<>();
@@ -134,7 +136,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/{type}/{language}/{name}", method = RequestMethod.GET)
     @ResponseBody
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public Content getContent(@PathVariable String type, @PathVariable String language, @PathVariable String name) throws ContentNotFoundException, CMSLiteException {
         Content content;
 
@@ -161,7 +163,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/string/{language}/{name}", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public void editStringContent(@PathVariable String language, @PathVariable String name,
                                   @RequestParam String value) throws ContentNotFoundException {
         StringContent stringContent = cmsLiteService.getStringContent(language, name);
@@ -180,7 +182,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/stream/{language}/{name}", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public void editStreamContent(@PathVariable String language, @PathVariable String name,
                                   @RequestParam MultipartFile file) throws ContentNotFoundException, IOException {
         StreamContent streamContent = cmsLiteService.getStreamContent(language, name);
@@ -204,7 +206,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource", method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public void addContent(@RequestParam String type,
                            @RequestParam String name,
                            @RequestParam String language,
@@ -263,7 +265,7 @@ public class ResourceController {
      */
     @RequestMapping(value = "/resource/{type}/{language}/{name}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('manageCMS')")
+    @PreAuthorize(CMS_ROLE)
     public void removeContent(@PathVariable String type, @PathVariable String language, @PathVariable String name) throws ContentNotFoundException, CMSLiteException {
         switch (type) {
             case "stream":


### PR DESCRIPTION
CMS-lite endpoint for retrieving stream and string contents should be unsecured, because purpose of this endpoints is to used them outside of the application. We do not need to be login as motech user to see stream content. 

Even in javadocs there is information that these endpoints should be used by external callers :  

> Retrieves the given stream content in raw form. Used by external callers to retrieve the content.